### PR TITLE
🔖 Prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7.0 (2023-08-31)
+
 Breaking changes:
 
 - Upgrade `@google-cloud` dependencies (e.g. Pub/Sub, Spanner) to latest major versions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.6.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Upgrade `@google-cloud` dependencies (e.g. Pub/Sub, Spanner) to latest major versions.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.7.0