### PR TITLE
🐛 Cloud Tasks task name formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fix:
+
+- Correctly format Cloud Tasks tasks names.
+
 ## v0.8.0 (2023-09-08)
 
 Features:

--- a/src/tasks/scheduler.spec.ts
+++ b/src/tasks/scheduler.spec.ts
@@ -75,7 +75,7 @@ describe('CloudTasksScheduler', () => {
       {
         parent: 'MY_QUEUE',
         task: {
-          name: 'MY_TASK',
+          name: `MY_QUEUE/tasks/MY_TASK`,
           scheduleTime: {
             seconds: Math.floor(scheduleDate.getTime() / 1000),
             nanos: (scheduleDate.getTime() % 1000) * 1e6,

--- a/src/tasks/scheduler.ts
+++ b/src/tasks/scheduler.ts
@@ -130,14 +130,14 @@ export class CloudTasksScheduler {
     const seconds = Math.floor(scheduleTime / 1000);
     const nanos = (scheduleTime - seconds * 1000) * 1e6;
 
+    const name = options.taskName
+      ? `${queue}/tasks/${options.taskName}`
+      : undefined;
+
     const [task] = await this.client.createTask(
       {
         parent: queue,
-        task: {
-          name: options.taskName,
-          httpRequest,
-          scheduleTime: { seconds, nanos },
-        },
+        task: { name, httpRequest, scheduleTime: { seconds, nanos } },
       },
       retry ? { retry: retry === true ? RETRY_CONFIG : retry } : {},
     );


### PR DESCRIPTION
This fixes a bug where Cloud Tasks tasks name should have the format `projects/<PROJECT_ID>/locations/<LOCATION_ID>/queues/<QUEUE_ID>/tasks/<TASK_ID>`.

### Commits

- 🐛 Fix formatting of optional Cloud Tasks name
- 📝 Update changelog