### PR TITLE
🔖 Prepare v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.8.1 (2023-09-08)
+
 Fix:
 
 - Correctly format Cloud Tasks tasks names.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.6.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Fix:

- Correctly format Cloud Tasks tasks names.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.8.1