### PR TITLE
🔖 Prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.0 (2023-09-11)
+
 Breaking changes:
 
 - Remove unnecessary generic for the `EventRequester`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.6.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Remove unnecessary generic for the `EventRequester`.

Features:

- Implement the `GoogleAppFixture`.
- Export the `SpannerKey` type.

Fixes:

- Remove users from the `AuthUsersFixture` when calling `deleteAll`.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.9.0