### PR TITLE
🐛 Exclude the Google healthcheck endpoint from the OpenAPI documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Exclude the Google healthcheck endpoint from the OpenAPI documentation.
+
 ## v0.10.0 (2023-09-12)
 
 Features:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.10.0",
       "license": "ISC",
       "dependencies": {
-        "@causa/runtime": ">= 0.6.1 < 1.0.0",
+        "@causa/runtime": ">= 0.7.0 < 1.0.0",
         "@google-cloud/precise-date": "^3.0.1",
         "@google-cloud/pubsub": "^4.0.5",
         "@google-cloud/spanner": "^7.0.0",
         "@google-cloud/tasks": "^4.0.1",
         "@grpc/grpc-js": "^1.9.2",
         "@nestjs/common": "^10.2.5",
-        "@nestjs/config": "^3.1.0",
+        "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.2.5",
         "@nestjs/passport": "^10.0.2",
         "@nestjs/swagger": "^7.1.11",
@@ -33,7 +33,7 @@
       },
       "devDependencies": {
         "@nestjs/testing": "^10.2.5",
-        "@tsconfig/node18": "^18.2.1",
+        "@tsconfig/node18": "^18.2.2",
         "@types/jest": "^29.5.4",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/node": "^18.17.15",
@@ -52,7 +52,7 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=16"
@@ -751,12 +751,12 @@
       "dev": true
     },
     "node_modules/@causa/runtime": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@causa/runtime/-/runtime-0.6.1.tgz",
-      "integrity": "sha512-d/xKW2bsJOP84GL2NBdRlSOevRd1pgl1FYjoFNGrAkOJh6kOyT2xz0IDp4oMxqEbP25Or1zHVE1LHIFeUQ9Ndw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@causa/runtime/-/runtime-0.7.0.tgz",
+      "integrity": "sha512-kdbcc0KfpbTzTCQC6r/+lNVL0sBldiURN4RJqKyamj8Uv3MaIHx7EQvysIUki5jiX31aBNJuXhWq4Ue3U6VGxw==",
       "dependencies": {
         "@nestjs/common": "^10.2.5",
-        "@nestjs/config": "^3.0.1",
+        "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.2.5",
         "@nestjs/passport": "^10.0.2",
         "@nestjs/platform-express": "^10.2.5",
@@ -769,7 +769,7 @@
         "pino": "^8.15.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
-        "uuid": "^9.0.0"
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=16"
@@ -1339,9 +1339,13 @@
       }
     },
     "node_modules/@google-cloud/storage/node_modules/teeny-request/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -2017,9 +2021,9 @@
       }
     },
     "node_modules/@nestjs/config": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-3.1.0.tgz",
-      "integrity": "sha512-yaAM30odymAD1d85QJreb0MXEu8AaHmTDl0q4jJTIKnjUnypjF1uO34/6ayYG2eY6jByBAtoRTxo8NCrlwBLUw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-3.1.1.tgz",
+      "integrity": "sha512-qu5QlNiJdqQtOsnB6lx4JCXPQ96jkKUsOGd+JXfXwqJqZcOSAq6heNFg0opW4pq4J/VZoNwoo87TNnx9wthnqQ==",
       "dependencies": {
         "dotenv": "16.3.1",
         "dotenv-expand": "10.0.0",
@@ -2029,6 +2033,14 @@
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "reflect-metadata": "^0.1.13"
+      }
+    },
+    "node_modules/@nestjs/config/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nestjs/core": {
@@ -2296,9 +2308,9 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.5.0.tgz",
-      "integrity": "sha512-636km3y3pVyJldKGp9qM+lPvxuOvhThUED9cHNPsERkp+APbdtCtj0sALW+mZsbQqnqQkNRHqoGw/Uc82UP6fQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
+      "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2452,9 +2464,9 @@
       "dev": true
     },
     "node_modules/@tsconfig/node18": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.1.tgz",
-      "integrity": "sha512-RDDZFuofwkcKpl8Vpj5wFbY+H53xOtqK7ckEL1sXsbPwvKwDdjQf3LkHbtt9sxIHn9nWIEwkmCwBRZ6z5TKU2A==",
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
+      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==",
       "dev": true
     },
     "node_modules/@types/accepts": {
@@ -3700,9 +3712,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001533",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001533.tgz",
-      "integrity": "sha512-9aY/b05NKU4Yl2sbcJhn4A7MsGwR1EPfW/nrqsnqVA0Oq50wpmPaGI+R1Z0UKlUl96oxUkGEOILWtOHck0eCWw==",
+      "version": "1.0.30001534",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001534.tgz",
+      "integrity": "sha512-vlPVrhsCS7XaSh2VvWluIQEzVhefrUQcEsQWSS5A5V+dM07uv1qHeQzAOTGIMy9i3e9bH15+muvI/UHojVgS/Q==",
       "dev": true,
       "funding": [
         {
@@ -4434,9 +4446,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.515",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.515.tgz",
-      "integrity": "sha512-VTq6vjk3kCfG2qdzQRd/i9dIyVVm0dbtZIgFzrLgfB73mXDQT2HPKVRc1EoZcAVUv9XhXAu08DWqJuababdGGg==",
+      "version": "1.4.519",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.519.tgz",
+      "integrity": "sha512-kqs9oGYL4UFVkLKhqCTgBCYZv+wZ374yABDMqlDda9HvlkQxvSr7kgf4hfWVjMieDbX+1MwPHFBsOGCMIBaFKg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -9458,9 +9470,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/config": "^3.1.0",
         "@nestjs/core": "^10.2.5",
         "@nestjs/passport": "^10.0.2",
+        "@nestjs/swagger": "^7.1.11",
         "@nestjs/terminus": "^10.0.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@nestjs/config": "^3.1.0",
     "@nestjs/core": "^10.2.5",
     "@nestjs/passport": "^10.0.2",
+    "@nestjs/swagger": "^7.1.11",
     "@nestjs/terminus": "^10.0.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     "test:cov": "npm run test -- --coverage"
   },
   "dependencies": {
-    "@causa/runtime": ">= 0.6.1 < 1.0.0",
+    "@causa/runtime": ">= 0.7.0 < 1.0.0",
     "@google-cloud/precise-date": "^3.0.1",
     "@google-cloud/pubsub": "^4.0.5",
     "@google-cloud/spanner": "^7.0.0",
     "@google-cloud/tasks": "^4.0.1",
     "@grpc/grpc-js": "^1.9.2",
     "@nestjs/common": "^10.2.5",
-    "@nestjs/config": "^3.1.0",
+    "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.2.5",
     "@nestjs/passport": "^10.0.2",
     "@nestjs/swagger": "^7.1.11",
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@nestjs/testing": "^10.2.5",
-    "@tsconfig/node18": "^18.2.1",
+    "@tsconfig/node18": "^18.2.2",
     "@types/jest": "^29.5.4",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/node": "^18.17.15",
@@ -72,6 +72,6 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.2.2",
-    "uuid": "^9.0.0"
+    "uuid": "^9.0.1"
   }
 }

--- a/src/healthcheck/controller.ts
+++ b/src/healthcheck/controller.ts
@@ -1,5 +1,6 @@
 import { HEALTHCHECK_ENDPOINT, Public } from '@causa/runtime/nestjs';
 import { Controller, Get } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
 import { HealthCheckResult, HealthCheckService } from '@nestjs/terminus';
 import { PubSubHealthIndicator } from '../pubsub/index.js';
 import { SpannerHealthIndicator } from '../spanner/index.js';
@@ -11,6 +12,7 @@ import { SpannerHealthIndicator } from '../spanner/index.js';
  * - Spanner
  */
 @Controller(HEALTHCHECK_ENDPOINT)
+@ApiExcludeController()
 export class GoogleHealthcheckController {
   constructor(
     private health: HealthCheckService,


### PR DESCRIPTION
The title says it all. The `/health` endpoint was appearing in the generated OpenAPI document.

### Commits

- ➕ Depend on @nestjs/swagger
- ⬆️ Upgrade dependencies
- 🐛 Exclude the Google healthcheck from the OpenAPI documentation
- 📝 Update changelog