### PR TITLE
🔖 Prepare v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.11.0 (2023-09-13)
+
 Features:
 
 - Disable batching in the `PubSubPublisher` by default, and allow per topic configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.7.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Disable batching in the `PubSubPublisher` by default, and allow per topic configuration.
- Support `MakeTestAppFactoryOptions` when creating a `GoogleAppFixture`.

Fixes:

- Exclude the Google healthcheck endpoint from the OpenAPI documentation.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.11.0