### PR TITLE
🔖 Prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.12.0 (2023-09-19)
+
 Breaking changes:
 
 - Entities returned by the `SpannerEntityManager` are now created by `class-transformer`. This means `@Transform` and `@Type` decorators can be used (e.g. to process the objects JSON columns, like dates).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.7.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Entities returned by the `SpannerEntityManager` are now created by `class-transformer`. This means `@Transform` and `@Type` decorators can be used (e.g. to process the objects JSON columns, like dates).

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.12.0