### PR TITLE
✨ Spanner lifecycle improvements and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Breaking changes:
 
 - Use NestJS `Type` for all references to class types.
 
+Features:
+
+- Expose the `Spanner` client from the `SpannerModule`.
+
+Fix:
+
+- Close the `Spanner` client and `Database` when the application terminates.
+
 ## v0.12.0 (2023-09-19)
 
 Breaking changes:

--- a/src/healthcheck/module.spec.ts
+++ b/src/healthcheck/module.spec.ts
@@ -33,7 +33,7 @@ describe('GoogleHealthcheckModule', () => {
         overrides: (builder) =>
           builder
             .overrideProvider(Database)
-            .useValue({ run: runMock })
+            .useValue({ run: runMock, close: () => Promise.resolve() })
             .overrideProvider(PubSub)
             .useValue({ getTopics: getTopicsMock }),
       }),

--- a/src/spanner/lifecycle.service.ts
+++ b/src/spanner/lifecycle.service.ts
@@ -1,0 +1,19 @@
+import { Database, Spanner } from '@google-cloud/spanner';
+import { Injectable, OnApplicationShutdown } from '@nestjs/common';
+
+/**
+ * A private service that handles the graceful shutdown of the Spanner Database.
+ * Should be imported in the `SpannerModule`.
+ */
+@Injectable()
+export class SpannerLifecycleService implements OnApplicationShutdown {
+  constructor(
+    private readonly spanner: Spanner,
+    private readonly database: Database,
+  ) {}
+
+  async onApplicationShutdown(): Promise<void> {
+    await this.database.close();
+    this.spanner.close();
+  }
+}

--- a/src/spanner/module.ts
+++ b/src/spanner/module.ts
@@ -8,6 +8,7 @@ import {
   catchSpannerDatabaseErrors,
 } from './database.js';
 import { SpannerEntityManager } from './entity-manager.js';
+import { SpannerLifecycleService } from './lifecycle.service.js';
 
 /**
  * Options when instantiating the Spanner {@link Database}.
@@ -75,6 +76,7 @@ export class SpannerModule {
         { provide: Spanner, useFactory: () => new Spanner() },
         makeDatabaseProvider(options),
         SpannerEntityManager,
+        SpannerLifecycleService,
       ],
       exports: [Spanner, Database, SpannerEntityManager],
     };

--- a/src/spanner/testing.ts
+++ b/src/spanner/testing.ts
@@ -28,12 +28,18 @@ export async function createDatabase(
      * By default, a new Spanner client will be created using the `SPANNER_INSTANCE` environment variable.
      */
     instance?: Instance;
+
+    /**
+     * The Spanner client to use to create the database.
+     * If `instance` is provided, this will be ignored.
+     */
+    spanner?: Spanner;
   } = {},
 ): Promise<Database> {
   const name = options.name ?? `test-${uuid.v4().slice(-10)}`;
+  const spanner = options.spanner ?? new Spanner();
   const instance =
-    options.instance ??
-    new Spanner().instance(process.env.SPANNER_INSTANCE ?? '');
+    options.instance ?? spanner.instance(process.env.SPANNER_INSTANCE ?? '');
   const sourceDatabaseName =
     options.sourceDatabaseName ?? process.env.SPANNER_DATABASE;
 


### PR DESCRIPTION
This PR make the `SpannerModule` export and manage the `Spanner` client. This allows the module to also handle the lifecycle of all Spanner objects (namely the `Spanner` client and the exported `Database`). Upon application shutdown, both the database and the client are closed by a lifecycle service.

### Commits

- ✨ Support the spanner option in createDatabase
- ✨ Export the Spanner client from the SpannerModule
- ✨ Close the Spanner database and client when the app terminates
- 📝 Update changelog