### PR TITLE
🔖 Prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.13.0 (2023-10-02)
+
 Breaking changes:
 
 - Use NestJS `Type` for all references to class types.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.8.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Use NestJS `Type` for all references to class types.

Features:

- Expose the `Spanner` client from the `SpannerModule`.
- Manage the `Spanner` client in the `GoogleAppFixture`.
- Make the failed `PubSubFixture` event expectation clearer.
- Add a default delay before checking that no message has been published to a topic in `PubSubFixture.expectNoMessageInTopic`.

Fix:

- Close the `Spanner` client and `Database` when the application terminates.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.13.0