### PR TITLE
🥅 Firestore error utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Features:
 
 - Rethrow transient errors as `RetryableError`s in the `CloudTasksScheduler`.
+- Implement the `convertFirestoreError` and `wrapFirestoreOperation` utilities.
+- Use `wrapFirestoreOperation` in the `FirestorePubSubTransactionRunner` to catch and rethrow Firestore errors as entity errors or `RetryableError`s.
 
 ## v0.14.0 (2023-11-08)
 

--- a/src/firestore/error-converter.spec.ts
+++ b/src/firestore/error-converter.spec.ts
@@ -1,0 +1,109 @@
+import {
+  EntityAlreadyExistsError,
+  EntityNotFoundError,
+  IncorrectEntityVersionError,
+} from '@causa/runtime';
+import { status } from '@grpc/grpc-js';
+import {
+  CollectionReference,
+  Firestore,
+  Timestamp,
+  getFirestore,
+} from 'firebase-admin/firestore';
+import { getDefaultFirebaseApp } from '../firebase/index.js';
+import { FirestoreCollection } from './collection.decorator.js';
+import { wrapFirestoreOperation } from './error-converter.js';
+import { TemporaryFirestoreError } from './errors.js';
+import {
+  clearFirestoreCollection,
+  createFirestoreTemporaryCollection,
+} from './testing.js';
+
+@FirestoreCollection({ name: 'tmpCol', path: (doc) => doc.id })
+class MyDocument {
+  constructor(readonly id: string) {}
+}
+
+describe('error converter', () => {
+  let firestore: Firestore;
+  let collection: CollectionReference<MyDocument>;
+
+  beforeAll(() => {
+    firestore = getFirestore(getDefaultFirebaseApp());
+    collection = createFirestoreTemporaryCollection(firestore, MyDocument);
+  });
+
+  afterEach(async () => {
+    await clearFirestoreCollection(collection);
+  });
+
+  describe('wrapFirestoreOperation', () => {
+    it('should run the operation and return the result', async () => {
+      const actualResult = await wrapFirestoreOperation(async () => {
+        await collection.doc('test').set(new MyDocument('test'));
+        return '🐑';
+      });
+
+      expect(actualResult).toEqual('🐑');
+      const actualDocument = await collection.doc('test').get();
+      expect(actualDocument.data()).toEqual({ id: 'test' });
+    });
+
+    it('should rethrow an unknown error', async () => {
+      const actualPromise = wrapFirestoreOperation(async () => {
+        throw new Error('🐑');
+      });
+
+      expect(actualPromise).rejects.toThrow('🐑');
+    });
+
+    it('should throw an EntityNotFoundError', async () => {
+      const actualPromise = wrapFirestoreOperation(async () => {
+        await collection.doc('test').update({ id: 'test' });
+      });
+
+      await expect(actualPromise).rejects.toThrow(EntityNotFoundError);
+    });
+
+    it('should throw an EntityAlreadyExistsError', async () => {
+      await collection.doc('test').set(new MyDocument('test'));
+
+      const actualPromise = wrapFirestoreOperation(async () => {
+        await collection.doc('test').create(new MyDocument('test'));
+      });
+
+      await expect(actualPromise).rejects.toThrow(EntityAlreadyExistsError);
+    });
+
+    it('should throw an IncorrectEntityVersionError', async () => {
+      await collection.doc('test').set(new MyDocument('test'));
+
+      const actualPromise = wrapFirestoreOperation(async () => {
+        await collection.doc('test').delete({
+          lastUpdateTime: new Timestamp(0, 0),
+        });
+      });
+
+      await expect(actualPromise).rejects.toThrow(IncorrectEntityVersionError);
+    });
+
+    it('should throw a TemporaryFirestoreError', async () => {
+      const errorCodes = [
+        status.CANCELLED,
+        status.DEADLINE_EXCEEDED,
+        status.INTERNAL,
+        status.UNAVAILABLE,
+      ];
+
+      for (const code of errorCodes) {
+        const actualPromise = wrapFirestoreOperation(async () => {
+          const error = new Error('🐑');
+          (error as any).code = code;
+          throw error;
+        });
+
+        await expect(actualPromise).rejects.toThrow(TemporaryFirestoreError);
+      }
+    });
+  });
+});

--- a/src/firestore/error-converter.ts
+++ b/src/firestore/error-converter.ts
@@ -1,0 +1,55 @@
+import {
+  EntityAlreadyExistsError,
+  EntityNotFoundError,
+  IncorrectEntityVersionError,
+} from '@causa/runtime';
+import { status } from '@grpc/grpc-js';
+import { TemporaryFirestoreError } from './errors.js';
+
+/**
+ * Converts a Firestore error to an entity error or a {@link TemporaryFirestoreError}.
+ * Entity errors do not provide details about the entity that caused the error, because it cannot be retrieved from the
+ * gRPC errors.
+ *
+ * @param error The error thrown by Firestore.
+ * @returns The converted error, or `undefined` if it could not be converted.
+ */
+export function convertFirestoreError(error: any): Error | undefined {
+  switch (error.code) {
+    case status.NOT_FOUND:
+      return new EntityNotFoundError(null, null);
+    case status.ALREADY_EXISTS:
+      return new EntityAlreadyExistsError(null, null);
+    case status.FAILED_PRECONDITION:
+      return new IncorrectEntityVersionError(
+        null,
+        null,
+        new Date(NaN),
+        new Date(NaN),
+      );
+    case status.CANCELLED:
+    case status.DEADLINE_EXCEEDED:
+    case status.INTERNAL:
+    case status.UNAVAILABLE:
+      return new TemporaryFirestoreError(error.message);
+    default:
+      return;
+  }
+}
+
+/**
+ * Runs a Firestore operation and converts its errors to entity errors or {@link TemporaryFirestoreError}s.
+ * Unrecognized errors are thrown as-is.
+ *
+ * @param operation The operation to wrap.
+ * @returns The result of the operation.
+ */
+export async function wrapFirestoreOperation<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    throw convertFirestoreError(error) ?? error;
+  }
+}

--- a/src/firestore/errors.ts
+++ b/src/firestore/errors.ts
@@ -1,0 +1,11 @@
+import { RetryableError } from '@causa/runtime';
+
+/**
+ * An error thrown when a Firestore operation fails due to a temporary error.
+ * Those errors are usually transient and can be retried.
+ */
+export class TemporaryFirestoreError extends RetryableError {
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/firestore/index.ts
+++ b/src/firestore/index.ts
@@ -7,4 +7,6 @@ export {
   convertFirestoreTimestampsToDates,
   makeFirestoreDataConverter,
 } from './converter.js';
+export { wrapFirestoreOperation } from './error-converter.js';
+export * from './errors.js';
 export { InjectFirestoreCollection } from './inject-collection.decorator.js';


### PR DESCRIPTION
This PR brings improvements to the Firestore utilities, to get closer to the error behaviour of Spanner utilities:

- `convertFirestoreError` is `convertSpannerToEntityError`'s counterpart for Firestore.
- `wrapFirestoreOperation` simply wraps a function and converts Firestore errors. This is exposed directly because there is no "Firestore entity manager" that could expose such a functionality. (For Spanner, this is the role of `SpannerEntityManager.transaction` & co.)
- The `FirestorePubSubTransactionRunner` now uses `wrapFirestoreOperation`, which means error conversion is transparent from within a `FirestorePubSubTransaction`.

### Commits

- ✨ Implement the convertFirestoreError and wrapFirestoreOperation utilities
- 🥅 Convert Firestore errors in the FirestorePubSubTransactionRunner
- 📝 Update changelog