### PR TITLE
🔖 Prepare v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.15.0 (2023-11-24)
+
 Features:
 
 - Rethrow transient errors as `RetryableError`s in the `CloudTasksScheduler`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.11.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Rethrow transient errors as `RetryableError`s in the `CloudTasksScheduler`.
- Implement the `convertFirestoreError` and `wrapFirestoreOperation` utilities.
- Use `wrapFirestoreOperation` in the `FirestorePubSubTransactionRunner` to catch and rethrow Firestore errors as entity errors or `RetryableError`s.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.15.0