### PR TITLE
🔖 Prepare v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.19.0 (2024-02-08)
+
 Features:
 
 - Implement the `PubSubEventPublishTime` decorator, to retrieve the `publishTime` for the message.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.15.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Implement the `PubSubEventPublishTime` decorator, to retrieve the `publishTime` for the message.

### Commits

- 📝 Update changelog
- 🔖 Set version to 0.19.0