### PR TITLE
🔖 Prepare v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.21.0 (2024-03-15)
+
 Features:
 
 - Support an optional `code` parameter for `TemporarySpannerError` and `TemporaryFirestoreError`, and provide a `retryableInTransaction` utility for both of them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.17.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Support an optional `code` parameter for `TemporarySpannerError` and `TemporaryFirestoreError`, and provide a `retryableInTransaction` utility for both of them.

Fixes:

- Ensure all retryable errors cases are handled for Firestore and Spanner.

### Commits

- **🔖 Set version to 0.21.0**
- **📝 Update changelog**