### PR TITLE
🔖 Prepare v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.22.0 (2024-03-19)
+
 Breaking changes:
 
 - `PubSubHealthIndicator` and `SpannerHealthIndicator` now extend the `BaseHealthIndicatorService`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.18.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- `PubSubHealthIndicator` and `SpannerHealthIndicator` now extend the `BaseHealthIndicatorService`.
- Remove the `GoogleHealthcheckModule`.

Features:

- Implement the `FirestoreHealthIndicator`.

### Commits

- **🔖 Set version to 0.22.0**
- **📝 Update changelog**