### PR TITLE
🐛 Do not remove interleaved rows when updating an entity using `SpannerEntityManager.update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Breaking changes:
 
 - Change types for versioned entity tests in the `GoogleAppFixture`.
 
+Fixes:
+
+- Do not remove interleaved rows when updating an entity using `SpannerEntityManager.update`.
+
 ## v0.23.0 (2024-04-01)
 
 Features:

--- a/src/spanner/entity-manager.ts
+++ b/src/spanner/entity-manager.ts
@@ -674,23 +674,26 @@ export class SpannerEntityManager {
         });
 
         let updatedInstance: T;
+        let operation: 'update' | 'insert';
         if (existingEntity) {
           if (options.validateFn) {
             options.validateFn(existingEntity);
           }
 
           updatedInstance = updateInstanceByColumn(existingEntity, update);
+          operation = 'update';
         } else if (options.upsert) {
           updatedInstance = copyInstanceWithMissingColumnsToNull(
             update,
             entityType,
           );
+          operation = 'insert';
         } else {
           throw new EntityNotFoundError(entityType, primaryKey);
         }
 
         const updateObj = instanceToSpannerObject(updatedInstance, entityType);
-        transaction.replace(tableName, updateObj);
+        transaction[operation](tableName, updateObj);
         return updatedInstance;
       },
     );


### PR DESCRIPTION
The title says it all. Using the `replace` operation from the mutation API removes interleaved rows. This is not expected when performing an `update` operation. Also, the `replace` operation is also exposed as a separate method in the `SpannerEntityManager` if needed.

### Commits

- **🐛 Do not remove interleaved rows when updating an entity**
- **📝 Update changelog**