### PR TITLE
🔖 Prepare v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.24.0 (2024-04-02)
+
 Breaking changes:
 
 - Change types for versioned entity tests in the `GoogleAppFixture`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.19.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Change types for versioned entity tests in the `GoogleAppFixture`.

Fixes:

- Do not remove interleaved rows when updating an entity using `SpannerEntityManager.update`.

### Commits

- **🔖 Set version to 0.24.0**
- **📝 Update changelog**