### PR TITLE
🐛 Loosen type constraint on `GoogleAppFixture.expectNonMutatedVersionedEntity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Loosen type constraint on `GoogleAppFixture.expectNonMutatedVersionedEntity`.
+
 ## v0.24.0 (2024-04-02)
 
 Breaking changes:

--- a/src/testing/google-app-fixture.ts
+++ b/src/testing/google-app-fixture.ts
@@ -176,7 +176,9 @@ export class GoogleAppFixture {
    * @param entity Describes the entity to fetch using the {@link SpannerEntityManager}.
    * @param tests The tests to run on the entity.
    */
-  async expectNonMutatedVersionedEntity<T extends VersionedEntity>(
+  async expectNonMutatedVersionedEntity<
+    T extends Pick<VersionedEntity, 'updatedAt'>,
+  >(
     entity: EntityToFetch<T>,
     tests: Omit<VersionedEntityTests<T>, 'expectedEvent'> & {
       // The function is not needed here, since the entity is not mutated.


### PR DESCRIPTION
The title says it all. This was missing from #74.

### Commits

- **🐛 Loosen type constraint on GoogleAppFixture.expectNonMutatedVersionedEntity**
- **📝 Update changelog**