### PR TITLE
🔖 Prepare v0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.24.1 (2024-04-02)
+
 Fixes:
 
 - Loosen type constraint on `GoogleAppFixture.expectNonMutatedVersionedEntity`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.19.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Loosen type constraint on `GoogleAppFixture.expectNonMutatedVersionedEntity`.

### Commits

- **🔖 Set version to 0.24.1**
- **📝 Update changelog**