### PR TITLE
🔖 Prepare v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.25.0 (2024-05-03)
+
 Breaking changes:
 
 - Remove the `PubSubEventHandlerModule`, as "interceptors are not providers". Prefer using `APP_INTERCEPTOR` or `@UseInterceptors` instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.24.1",
+      "version": "0.25.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.20.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Remove the `PubSubEventHandlerModule`, as "interceptors are not providers". Prefer using `APP_INTERCEPTOR` or `@UseInterceptors` instead.

Features:

- Add the `withSerializer` static method to the `PubSubEventHandlerInterceptor`.

### Commits

- **🔖 Set version to 0.25.0**
- **📝 Update changelog**