### PR TITLE
🐛 Close the Pub/Sub client in the `PubSubFixture`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Fixes:
 
 - Add `RESOURCE_EXHAUSTED` to the list of retryable statuses for Spanner errors.
+- Close the Pub/Sub client after having deleted all topic fixtures.
 
 ## v0.27.0 (2024-05-24)
 

--- a/src/pubsub/testing/fixture.ts
+++ b/src/pubsub/testing/fixture.ts
@@ -63,6 +63,11 @@ export class PubSubFixture {
   readonly pubSub: PubSub;
 
   /**
+   * Whether the Pub/Sub client is managed by the fixture.
+   */
+  private readonly isManagedClient: boolean;
+
+  /**
    * The (de)serializer to use for Pub/Sub messages.
    */
   readonly serializer: ObjectSerializer;
@@ -110,6 +115,7 @@ export class PubSubFixture {
     } = {},
   ) {
     this.pubSub = options.pubSub ?? new PubSub();
+    this.isManagedClient = !options.pubSub;
     this.serializer = options.serializer ?? new JsonObjectSerializer();
   }
 
@@ -319,6 +325,7 @@ export class PubSubFixture {
 
   /**
    * Deletes all previously created temporary topics.
+   * If the Pub/Sub client was managed by the fixture (it wasn't passed as an option), it is also closed.
    */
   async deleteAll(): Promise<void> {
     await Promise.all(
@@ -326,5 +333,9 @@ export class PubSubFixture {
         this.delete(sourceTopicName),
       ),
     );
+
+    if (this.isManagedClient) {
+      await this.pubSub.close();
+    }
   }
 }


### PR DESCRIPTION
This closes the `PubSubFixture.pubSub` client, only if it was not specified as an option. Otherwise, it is assumed that the client is managed by the caller.

### Commits

- **🐛 Close the Pub/Sub client after having deleted all topic fixtures**
- **📝 Update changelog**