### PR TITLE
🔖 Prepare v0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.27.1 (2024-05-30)
+
 Fixes:
 
 - Add `RESOURCE_EXHAUSTED` to the list of retryable statuses for Spanner errors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.20.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Add `RESOURCE_EXHAUSTED` to the list of retryable statuses for Spanner errors.
- Close the Pub/Sub client after having deleted all topic fixtures.

### Commits

- **🔖 Set version to 0.27.1**
- **📝 Update changelog**