### PR TITLE
🔖 Prepare v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.30.0 (2024-09-04)
+
 Features:
 
 - Export `getFirestoreCollectionInjectionName` to get the injection token for a Firestore collection.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.22.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Export `getFirestoreCollectionInjectionName` to get the injection token for a Firestore collection.

### Commits

- **🔖 Set version to 0.30.0**
- **📝 Update changelog**