### PR TITLE
🔖 Prepare v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.31.0 (2024-09-13)
+
 Features:
 
 - Implement `CloudTasksScheduler.getQueuePath`, to get the full resource name for a queue from the configuration.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.22.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Implement `CloudTasksScheduler.getQueuePath`, to get the full resource name for a queue from the configuration.

### Commits

- **🔖 Set version to 0.31.0**
- **📝 Update changelog**