### PR TITLE
`FirebaseAdminClient` and `FirestoreHealthIndicator` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Features:
+
+- Make the `FirebaseModule` provide the `FirestoreAdminClient`.
+- Make the `FirestoreHealthIndicator` get the database instead of listing collections.
+
 ## v0.31.0 (2024-09-13)
 
 Features:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,15 @@
       "dependencies": {
         "@causa/runtime": ">= 0.22.0 < 1.0.0",
         "@google-cloud/precise-date": "^4.0.0",
-        "@google-cloud/pubsub": "^4.7.1",
+        "@google-cloud/pubsub": "^4.7.2",
         "@google-cloud/spanner": "^7.14.0",
         "@google-cloud/tasks": "^5.5.0",
-        "@grpc/grpc-js": "^1.11.2",
-        "@nestjs/common": "^10.4.1",
+        "@grpc/grpc-js": "^1.11.3",
+        "@nestjs/common": "^10.4.3",
         "@nestjs/config": "^3.2.3",
-        "@nestjs/core": "^10.4.1",
+        "@nestjs/core": "^10.4.3",
         "@nestjs/passport": "^10.0.3",
-        "@nestjs/swagger": "^7.4.0",
+        "@nestjs/swagger": "^7.4.2",
         "@nestjs/terminus": "^10.2.3",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
@@ -32,10 +32,10 @@
         "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {
-        "@nestjs/testing": "^10.4.1",
+        "@nestjs/testing": "^10.4.3",
         "@tsconfig/node18": "^18.2.4",
         "@types/jest": "^29.5.13",
-        "@types/jsonwebtoken": "^9.0.6",
+        "@types/jsonwebtoken": "^9.0.7",
         "@types/node": "^18.19.50",
         "@types/passport-http-bearer": "^1.0.41",
         "@types/supertest": "^6.0.2",
@@ -51,7 +51,7 @@
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.5.4",
-        "typescript-eslint": "^8.5.0",
+        "typescript-eslint": "^8.6.0",
         "uuid": "^10.0.0"
       },
       "engines": {
@@ -808,9 +808,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -964,52 +964,52 @@
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/component": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.8.tgz",
-      "integrity": "sha512-LcNvxGLLGjBwB0dJUsBGCej2fqAepWyBubs4jt1Tiuns7QLbXHuyObZ4aMeBjZjWx4m8g1LoVI9QFpSaq/k4/g==",
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.9.tgz",
+      "integrity": "sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.9.7",
+        "@firebase/util": "1.10.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.7.tgz",
-      "integrity": "sha512-wjXr5AO8RPxVVg7rRCYffT7FMtBjHRfJ9KMwi19MbOf0vBf0H9YqW3WCgcnLpXI6ehiUcU3z3qgPnnU0nK6SnA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.8.tgz",
+      "integrity": "sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.2",
         "@firebase/auth-interop-types": "0.2.3",
-        "@firebase/component": "0.6.8",
+        "@firebase/component": "0.6.9",
         "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
+        "@firebase/util": "1.10.0",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.7.tgz",
-      "integrity": "sha512-R/3B+VVzEFN5YcHmfWns3eitA8fHLTL03io+FIoMcTYkajFnrBdS3A+g/KceN9omP7FYYYGTQWF9lvbEx6eMEg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.8.tgz",
+      "integrity": "sha512-OpeWZoPE3sGIRPBKYnW9wLad25RaWbGyk7fFQe4xnJQKRzlynWeFBSRRAoLE2Old01WXwskUiucNqUUVlFsceg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.8",
-        "@firebase/database": "1.0.7",
-        "@firebase/database-types": "1.0.4",
+        "@firebase/component": "0.6.9",
+        "@firebase/database": "1.0.8",
+        "@firebase/database-types": "1.0.5",
         "@firebase/logger": "0.4.2",
-        "@firebase/util": "1.9.7",
+        "@firebase/util": "1.10.0",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.4.tgz",
-      "integrity": "sha512-mz9ZzbH6euFXbcBo+enuJ36I5dR5w+enJHHjy9Y5ThCdKUseqfDjW3vCp1YxE9zygFCSjJJ/z1cQ+zodvUcwPQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.5.tgz",
+      "integrity": "sha512-fTlqCNwFYyq/C6W7AJ5OCuq5CeZuBEsEwptnVxlNPkWCo5cTTyukzAHRSO/jaQcItz33FfYrrFk1SJofcu2AaQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@firebase/app-types": "0.9.2",
-        "@firebase/util": "1.9.7"
+        "@firebase/util": "1.10.0"
       }
     },
     "node_modules/@firebase/logger": {
@@ -1022,9 +1022,9 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.7.tgz",
-      "integrity": "sha512-fBVNH/8bRbYjqlbIhZ+lBtdAAS4WqZumx03K06/u7fJSpz1TGjEMm1ImvKD47w+xaFKIP2ori6z8BrbakRfjJA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
+      "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -1108,9 +1108,9 @@
       }
     },
     "node_modules/@google-cloud/pubsub": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-4.7.1.tgz",
-      "integrity": "sha512-g6RN//1WjEg5pUqAT1xJZDFmhC5nitFVHYyS52THSl7VKubWv+T9cHkeHp/+cc1HDUbkMRjs5hwVSoa0bRR+8Q==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-4.7.2.tgz",
+      "integrity": "sha512-N9Cziu5d7sju4gtHsbbjOXDMCewNwGaPZ/o+sBbWl9sBR7S+kHkD4BVg6hCi9SvH1sst0AGan8UAQAxbac8cRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
@@ -1207,9 +1207,9 @@
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.12.1.tgz",
-      "integrity": "sha512-Z3ZzOnF3YKLuvpkvF+TjQ6lztxcAyTILp+FjKonmVpEwPa9vFvxpZjubLR4sB6bf19i/8HL2AXRjA0YFgHFRmQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.13.0.tgz",
+      "integrity": "sha512-Y0rYdwM5ZPW3jw/T26sMxxfPrVQTKm9vGrZG8PRyGuUmUJ8a2xNuQ9W/NNA1prxqv2i54DSydV8SJqxF2oCVgA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -1256,9 +1256,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.2.tgz",
-      "integrity": "sha512-DWp92gDD7/Qkj7r8kus6/HCINeo3yPZWZ3paKgDgsbKbSpoxKg1yvN8xe2Q8uE3zOsPe3bX8FQX2+XValq2yTw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.3.tgz",
+      "integrity": "sha512-i9UraDzFHMR+Iz/MhFLljT+fCpgxZ3O6CxwGJ8YuNYHJItIHUzKJpW2LvoFZNnGPwqc9iWy9RAucxV0JoR9aUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
@@ -1915,13 +1915,13 @@
       "license": "MIT"
     },
     "node_modules/@nestjs/common": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.1.tgz",
-      "integrity": "sha512-4CkrDx0s4XuWqFjX8WvOFV7Y6RGJd0P2OBblkhZS7nwoctoSuW5pyEa8SWak6YHNGrHRpFb6ymm5Ai4LncwRVA==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.3.tgz",
+      "integrity": "sha512-4hbLd3XIJubHSylYd/1WSi4VQvG68KM/ECYpMDqA3k3J1/T17SAg40sDoq3ZoO5OZgU0xuNyjuISdOTjs11qVg==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
-        "tslib": "2.6.3",
+        "tslib": "2.7.0",
         "uid": "2.0.2"
       },
       "funding": {
@@ -1959,17 +1959,17 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.1.tgz",
-      "integrity": "sha512-9I1WdfOBCCHdUm+ClBJupOuZQS6UxzIWHIq6Vp1brAA5ZKl/Wq6BVwSsbnUJGBy3J3PM2XHmR0EQ4fwX3nR7lA==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.3.tgz",
+      "integrity": "sha512-6OQz+5C8mT8yRtfvE5pPCq+p6w5jDot+oQku1KzQ24ABn+lay1KGuJwcKZhdVNuselx+8xhdMxknZTA8wrGLIg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "path-to-regexp": "3.2.0",
-        "tslib": "2.6.3",
+        "path-to-regexp": "3.3.0",
+        "tslib": "2.7.0",
         "uid": "2.0.2"
       },
       "funding": {
@@ -2027,16 +2027,16 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.1.tgz",
-      "integrity": "sha512-ccfqIDAq/bg1ShLI5KGtaLaYGykuAdvCi57ohewH7eKJSIpWY1DQjbgKlFfXokALYUq1YOMGqjeZ244OWHfDQg==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.3.tgz",
+      "integrity": "sha512-ss7gkofVm3eO+1P9iRhmGq6Xcjg+mIN3dWisKJZYelSV+msb0QpJmqChLvWjLkWtlqDnx915FKUk0IzCa0TVzw==",
       "license": "MIT",
       "dependencies": {
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "cors": "2.8.5",
-        "express": "4.19.2",
+        "express": "4.21.0",
         "multer": "1.4.4-lts.1",
-        "tslib": "2.6.3"
+        "tslib": "2.7.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2047,155 +2047,17 @@
         "@nestjs/core": "^10.0.0"
       }
     },
-    "node_modules/@nestjs/platform-express/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@nestjs/platform-express/node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.6.0",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/@nestjs/platform-express/node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@nestjs/platform-express/node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "license": "MIT"
-    },
-    "node_modules/@nestjs/platform-express/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@nestjs/platform-express/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@nestjs/platform-express/node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
-      "license": "MIT"
-    },
-    "node_modules/@nestjs/platform-express/node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/@nestjs/platform-express/node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
-      "license": "MIT",
-      "dependencies": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.18.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/@nestjs/swagger": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.0.tgz",
-      "integrity": "sha512-dCiwKkRxcR7dZs5jtrGspBAe/nqJd1AYzOBTzw9iCdbq3BGrLpwokelk6lFZPe4twpTsPQqzNKBwKzVbI6AR/g==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.2.tgz",
+      "integrity": "sha512-Mu6TEn1M/owIvAx2B4DUQObQXqo2028R2s9rSZ/hJEgBK95+doTwS0DjmVA2wTeZTyVtXOoN7CsoM5pONBzvKQ==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "^0.15.0",
         "@nestjs/mapped-types": "2.0.5",
         "js-yaml": "4.1.0",
         "lodash": "4.17.21",
-        "path-to-regexp": "3.2.0",
+        "path-to-regexp": "3.3.0",
         "swagger-ui-dist": "5.17.14"
       },
       "peerDependencies": {
@@ -2289,13 +2151,13 @@
       }
     },
     "node_modules/@nestjs/testing": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.1.tgz",
-      "integrity": "sha512-pR+su5+YGqCLH0RhhVkPowQK7FCORU0/PWAywPK7LScAOtD67ZoviZ7hAU4vnGdwkg4HCB0D7W8Bkg19CGU8Xw==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.3.tgz",
+      "integrity": "sha512-SBNWrMU51YAlYmW86wyjlGZ2uLnASNiOPD0lBcNIlxxei0b05/aI3nh7OPuxbXQUdedUJfPq2d2jZj4TRG4S0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tslib": "2.6.3"
+        "tslib": "2.7.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2757,9 +2619,9 @@
       }
     },
     "node_modules/@types/jsonwebtoken": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
-      "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.7.tgz",
+      "integrity": "sha512-ugo316mmTYBl2g81zDFnZ7cfxlut3o+/EQdaP7J8QN2kY6lJ22hmQYCK5EHcJHbrW+dkCGSCPgbG8JtYj6qSrg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2860,9 +2722,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.15",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
-      "integrity": "sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==",
+      "version": "6.9.16",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
+      "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
@@ -2969,9 +2831,9 @@
       "license": "MIT"
     },
     "node_modules/@types/validator": {
-      "version": "13.12.1",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.1.tgz",
-      "integrity": "sha512-w0URwf7BQb0rD/EuiG12KP0bailHKHP5YVviJG9zw3ykAokL0TuxU2TUqMB7EwZ59bDHYdeTIvjI5m0S7qHfOA==",
+      "version": "13.12.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.2.tgz",
+      "integrity": "sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -2992,17 +2854,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.5.0.tgz",
-      "integrity": "sha512-lHS5hvz33iUFQKuPFGheAB84LwcJ60G8vKnEhnfcK1l8kGVLro2SFYW6K0/tj8FUhRJ0VHyg1oAfg50QGbPPHw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.6.0.tgz",
+      "integrity": "sha512-UOaz/wFowmoh2G6Mr9gw60B1mm0MzUtm6Ic8G2yM1Le6gyj5Loi/N+O5mocugRGY+8OeeKmkMmbxNqUCq3B4Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/type-utils": "8.5.0",
-        "@typescript-eslint/utils": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/type-utils": "8.6.0",
+        "@typescript-eslint/utils": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -3026,16 +2888,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.5.0.tgz",
-      "integrity": "sha512-gF77eNv0Xz2UJg/NbpWJ0kqAm35UMsvZf1GHj8D9MRFTj/V3tAciIWXfmPLsAAF/vUlpWPvUDyH1jjsr0cMVWw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.6.0.tgz",
+      "integrity": "sha512-eQcbCuA2Vmw45iGfcyG4y6rS7BhWfz9MQuk409WD47qMM+bKCGQWXxvoOs1DUp+T7UBMTtRTVT+kXr7Sh4O9Ow==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/typescript-estree": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3080,14 +2942,14 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.5.0.tgz",
-      "integrity": "sha512-06JOQ9Qgj33yvBEx6tpC8ecP9o860rsR22hWMEd12WcTRrfaFgHr2RB/CA/B+7BMhHkXT4chg2MyboGdFGawYg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
+      "integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0"
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3098,14 +2960,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.5.0.tgz",
-      "integrity": "sha512-N1K8Ix+lUM+cIDhL2uekVn/ZD7TZW+9/rwz8DclQpcQ9rk4sIL5CAlBC0CugWKREmDjBzI/kQqU4wkg46jWLYA==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.6.0.tgz",
+      "integrity": "sha512-dtePl4gsuenXVwC7dVNlb4mGDcKjDT/Ropsk4za/ouMBPplCLyznIaR+W65mvCvsyS97dymoBRrioEXI7k0XIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.5.0",
-        "@typescript-eslint/utils": "8.5.0",
+        "@typescript-eslint/typescript-estree": "8.6.0",
+        "@typescript-eslint/utils": "8.6.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -3148,9 +3010,9 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.5.0.tgz",
-      "integrity": "sha512-qjkormnQS5wF9pjSi6q60bKUHH44j2APxfh9TQRXK8wbYVeDYYdYJGIROL87LGZZ2gz3Rbmjc736qyL8deVtdw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
+      "integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3162,14 +3024,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.5.0.tgz",
-      "integrity": "sha512-vEG2Sf9P8BPQ+d0pxdfndw3xIXaoSjliG0/Ejk7UggByZPKXmJmw3GW5jV2gHNQNawBUyfahoSiCFVov0Ruf7Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
+      "integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -3255,16 +3117,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.5.0.tgz",
-      "integrity": "sha512-6yyGYVL0e+VzGYp60wvkBHiqDWOpT63pdMV2CVG4LVDd5uR6q1qQN/7LafBZtAtNIn/mqXjsSeS5ggv/P0iECw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.6.0.tgz",
+      "integrity": "sha512-eNp9cWnYf36NaOVjkEUznf6fEgVy1TWpE0o52e4wtojjBx7D1UV2WAWGzR+8Y5lVFtpMLPwNbC67T83DWSph4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/typescript-estree": "8.5.0"
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.6.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3278,13 +3140,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.5.0.tgz",
-      "integrity": "sha512-yTPqMnbAZJNy2Xq2XU8AdtOW9tJIr+UQb64aXB9f3B1498Zx9JorVgFJcZpEc9UBuCCrdzKID2RGAMkYcDtZOw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
+      "integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/types": "8.6.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -3736,9 +3598,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -3749,7 +3611,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -3974,9 +3836,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001660",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001660.tgz",
-      "integrity": "sha512-GacvNTTuATm26qC74pt+ad1fW15mlQ/zuTzzY1ZoIzECTP8HURDfF43kNxPgf7H1jmelCBQTTbBNxdSXOA7Bqg==",
+      "version": "1.0.30001662",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001662.tgz",
+      "integrity": "sha512-sgMUVwLmGseH8ZIrm1d51UbrhqMCH3jvS7gF/M6byuHOnKyLOBL7W8yz5V02OHwgLGA36o/AFhWzzh4uc5aqTA==",
       "dev": true,
       "funding": [
         {
@@ -4595,9 +4457,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.21",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.21.tgz",
-      "integrity": "sha512-+rBAerCpQvFSPyAO677i5gJuWGO2WFsoujENdcMzsrpP7Ebcc3pmpERgU8CV4fFF10a5haP4ivnFQ/AmLICBVg==",
+      "version": "1.5.25",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.25.tgz",
+      "integrity": "sha512-kMb204zvK3PsSlgvvwzI3wBIcAw15tRkYk+NQdsjdDtcQWTp2RABbMQ9rUBy8KNEOM+/E6ep+XC3AykiWZld4g==",
       "dev": true,
       "license": "ISC"
     },
@@ -5065,65 +4927,11 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/express/node_modules/path-to-regexp": {
       "version": "0.1.10",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
       "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
       "license": "MIT"
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5387,9 +5195,9 @@
       }
     },
     "node_modules/firebase-admin/node_modules/@types/node": {
-      "version": "22.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "version": "22.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
+      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -8070,9 +7878,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
-      "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
       "license": "MIT"
     },
     "node_modules/pause": {
@@ -8489,12 +8297,12 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -9656,9 +9464,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -9730,15 +9538,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.5.0.tgz",
-      "integrity": "sha512-uD+XxEoSIvqtm4KE97etm32Tn5MfaZWgWfMMREStLxR6JzvHkc2Tkj7zhTEK5XmtpTmKHNnG8Sot6qDfhHtR1Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.6.0.tgz",
+      "integrity": "sha512-eEhhlxCEpCd4helh3AO1hk0UP2MvbRi9CtIAJTVPQjuSXOOO2jsEacNi4UdcJzZJbeuVg1gMhtZ8UYb+NFYPrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.5.0",
-        "@typescript-eslint/parser": "8.5.0",
-        "@typescript-eslint/utils": "8.5.0"
+        "@typescript-eslint/eslint-plugin": "8.6.0",
+        "@typescript-eslint/parser": "8.6.0",
+        "@typescript-eslint/utils": "8.6.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -31,15 +31,15 @@
   "dependencies": {
     "@causa/runtime": ">= 0.22.0 < 1.0.0",
     "@google-cloud/precise-date": "^4.0.0",
-    "@google-cloud/pubsub": "^4.7.1",
+    "@google-cloud/pubsub": "^4.7.2",
     "@google-cloud/spanner": "^7.14.0",
     "@google-cloud/tasks": "^5.5.0",
-    "@grpc/grpc-js": "^1.11.2",
-    "@nestjs/common": "^10.4.1",
+    "@grpc/grpc-js": "^1.11.3",
+    "@nestjs/common": "^10.4.3",
     "@nestjs/config": "^3.2.3",
-    "@nestjs/core": "^10.4.1",
+    "@nestjs/core": "^10.4.3",
     "@nestjs/passport": "^10.0.3",
-    "@nestjs/swagger": "^7.4.0",
+    "@nestjs/swagger": "^7.4.2",
     "@nestjs/terminus": "^10.2.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
@@ -52,10 +52,10 @@
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
-    "@nestjs/testing": "^10.4.1",
+    "@nestjs/testing": "^10.4.3",
     "@tsconfig/node18": "^18.2.4",
     "@types/jest": "^29.5.13",
-    "@types/jsonwebtoken": "^9.0.6",
+    "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^18.19.50",
     "@types/passport-http-bearer": "^1.0.41",
     "@types/supertest": "^6.0.2",
@@ -71,7 +71,7 @@
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
-    "typescript-eslint": "^8.5.0",
+    "typescript-eslint": "^8.6.0",
     "uuid": "^10.0.0"
   }
 }

--- a/src/firebase/firestore-admin-client.type.ts
+++ b/src/firebase/firestore-admin-client.type.ts
@@ -1,0 +1,7 @@
+import { v1 } from 'firebase-admin/firestore';
+
+/**
+ * The low-level client to access administrative Firestore operations.
+ */
+export const FirestoreAdminClient = v1.FirestoreAdminClient;
+export type FirestoreAdminClient = InstanceType<typeof v1.FirestoreAdminClient>;

--- a/src/firebase/index.ts
+++ b/src/firebase/index.ts
@@ -1,4 +1,5 @@
 export { getDefaultFirebaseApp } from './app.js';
+export { FirestoreAdminClient } from './firestore-admin-client.type.js';
 export {
   FIREBASE_APP_TOKEN,
   InjectFirebaseApp,

--- a/src/firebase/lifecycle.service.ts
+++ b/src/firebase/lifecycle.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { App, deleteApp } from 'firebase-admin/app';
 import { Firestore } from 'firebase-admin/firestore';
+import { FirestoreAdminClient } from './firestore-admin-client.type.js';
 import { InjectFirebaseApp } from './inject-firebase-app.decorator.js';
 
 /**
@@ -13,9 +14,11 @@ export class FirebaseLifecycleService implements OnApplicationShutdown {
     @InjectFirebaseApp()
     private readonly app: App,
     private readonly firestore: Firestore,
+    private readonly firestoreAdmin: FirestoreAdminClient,
   ) {}
 
   async onApplicationShutdown(): Promise<void> {
+    await this.firestoreAdmin.close();
     await this.firestore.terminate();
     await deleteApp(this.app);
   }

--- a/src/firebase/module.spec.ts
+++ b/src/firebase/module.spec.ts
@@ -4,10 +4,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { App, deleteApp } from 'firebase-admin/app';
 import { AppCheck } from 'firebase-admin/app-check';
 import { Auth, getAuth } from 'firebase-admin/auth';
-import { Firestore } from 'firebase-admin/firestore';
+import { Firestore, v1 } from 'firebase-admin/firestore';
 import { Messaging } from 'firebase-admin/messaging';
 import 'jest-extended';
 import { getDefaultFirebaseApp } from './app.js';
+import { FirestoreAdminClient } from './firestore-admin-client.type.js';
 import { InjectFirebaseApp } from './inject-firebase-app.decorator.js';
 import { FirebaseModule, FirebaseModuleOptions } from './module.js';
 
@@ -21,6 +22,7 @@ describe('FirebaseModule', () => {
       readonly auth: Auth,
       readonly appCheck: AppCheck,
       readonly messaging: Messaging,
+      readonly firestoreAdmin: FirestoreAdminClient,
     ) {}
   }
 
@@ -83,6 +85,12 @@ describe('FirebaseModule', () => {
     await createInjectedService();
 
     expect(service.messaging).toBeInstanceOf(Messaging);
+  });
+
+  it('should inject the FirestoreAdminClient', async () => {
+    await createInjectedService();
+
+    expect(service.firestoreAdmin).toBeInstanceOf(v1.FirestoreAdminClient);
   });
 
   it('should use options when initializing the app', async () => {

--- a/src/firebase/module.ts
+++ b/src/firebase/module.ts
@@ -13,6 +13,7 @@ import { Auth, getAuth } from 'firebase-admin/auth';
 import { Firestore, getFirestore } from 'firebase-admin/firestore';
 import { Messaging, getMessaging } from 'firebase-admin/messaging';
 import { getDefaultFirebaseApp } from './app.js';
+import { FirestoreAdminClient } from './firestore-admin-client.type.js';
 import { FIREBASE_APP_TOKEN } from './inject-firebase-app.decorator.js';
 import { FirebaseLifecycleService } from './lifecycle.service.js';
 
@@ -36,6 +37,10 @@ const childProviders: (
     provide: Messaging,
     useFactory: getMessaging,
     inject: [FIREBASE_APP_TOKEN],
+  },
+  {
+    provide: FirestoreAdminClient,
+    useFactory: () => new FirestoreAdminClient(),
   },
 ];
 

--- a/src/firestore/healthcheck.spec.ts
+++ b/src/firestore/healthcheck.spec.ts
@@ -1,9 +1,9 @@
 import { HealthCheckModule, createApp } from '@causa/runtime/nestjs';
 import { jest } from '@jest/globals';
 import { INestApplication, Module } from '@nestjs/common';
-import { Firestore } from 'firebase-admin/firestore';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent.js';
+import { FirestoreAdminClient } from '../firebase/index.js';
 import { FirebaseModule } from '../firebase/module.js';
 import { FirestoreHealthIndicator } from './healthcheck.js';
 
@@ -17,10 +17,12 @@ export class HealthModule {}
 
 describe('FirestoreHealthIndicator', () => {
   let app: INestApplication;
+  let adminClient: FirestoreAdminClient;
   let request: TestAgent<supertest.Test>;
 
   beforeEach(async () => {
     app = await createApp(HealthModule);
+    adminClient = app.get(FirestoreAdminClient);
     request = supertest(app.getHttpServer());
   });
 
@@ -29,17 +31,23 @@ describe('FirestoreHealthIndicator', () => {
   });
 
   it('should return 200 when Firestore can be reached', async () => {
+    jest.spyOn(adminClient as any, 'getDatabase').mockResolvedValue([]);
+
     await request.get('/health').expect(200, {
       status: 'ok',
       info: { 'google.firestore': { status: 'up' } },
       error: {},
       details: { 'google.firestore': { status: 'up' } },
     });
+
+    expect(adminClient.getDatabase).toHaveBeenCalledWith({
+      name: `projects/${process.env.GCLOUD_PROJECT}/databases/(default)`,
+    });
   });
 
   it('should return 503 when Firestore cannot be reached', async () => {
     jest
-      .spyOn(app.get(Firestore), 'listCollections')
+      .spyOn(adminClient as any, 'getDatabase')
       .mockRejectedValue(new Error('💥'));
 
     await request.get('/health').expect(503, {
@@ -47,6 +55,10 @@ describe('FirestoreHealthIndicator', () => {
       info: {},
       error: { 'google.firestore': { status: 'down', error: '💥' } },
       details: { 'google.firestore': { status: 'down', error: '💥' } },
+    });
+
+    expect(adminClient.getDatabase).toHaveBeenCalledWith({
+      name: `projects/${process.env.GCLOUD_PROJECT}/databases/(default)`,
     });
   });
 });

--- a/src/firestore/healthcheck.ts
+++ b/src/firestore/healthcheck.ts
@@ -2,6 +2,7 @@ import { BaseHealthIndicatorService } from '@causa/runtime/nestjs';
 import { Injectable } from '@nestjs/common';
 import { HealthCheckError, HealthIndicatorResult } from '@nestjs/terminus';
 import { Firestore } from 'firebase-admin/firestore';
+import { FirestoreAdminClient } from '../firebase/index.js';
 
 /**
  * The key used to identify the Firestore health indicator.
@@ -13,17 +14,30 @@ const FIRESTORE_HEALTH_KEY = 'google.firestore';
  */
 @Injectable()
 export class FirestoreHealthIndicator extends BaseHealthIndicatorService {
-  constructor(private readonly firestore: Firestore) {
+  /**
+   * The ID of the database used by Firestore.
+   */
+  private readonly databaseId: string;
+
+  constructor(
+    private readonly admin: FirestoreAdminClient,
+    firestore: Firestore,
+  ) {
     super();
+
+    this.databaseId = firestore.databaseId;
   }
 
   async check(): Promise<HealthIndicatorResult> {
     try {
-      await this.firestore.listCollections();
+      const projectId = await this.admin.getProjectId();
+      const name = this.admin.databasePath(projectId, this.databaseId);
+      await this.admin.getDatabase({ name });
+
       return this.getStatus(FIRESTORE_HEALTH_KEY, true);
     } catch (error: any) {
       throw new HealthCheckError(
-        'Failed to check health by listing Firestore collections.',
+        'Failed to check health by getting Firestore database.',
         this.getStatus(FIRESTORE_HEALTH_KEY, false, {
           error: error.message,
         }),


### PR DESCRIPTION
This PR does two things:

- It initialises and exposes the `FirebaseAdminClient` in the `FirebaseModule`.
- It uses this `FirebaseAdminClient` in the `FirestoreHealthIndicator`, by getting the current database information, rather than list collections in it.

The reason for the second item is that list collections is counted as a read operation and can lead to costs (although they should be negligible). On the other hand `GetDatabase` does not have limits or costs associated with it.
The only downside is that it is an admin operation, which might not be as close as listing collections when it comes to having a request similar to client operations. However it is likely that `GetDatabase` actually makes a request to the database, therefore testing its connectivity.

### Commits

- **⬆️ Upgrade dependencies**
- **✨ Make the FirebaseModule provide the FirestoreAdminClient**
- **✨ Make the FirestoreHealthIndicator get the database instead of listing collections**
- **📝 Update changelog**