### PR TITLE
🔖 Prepare v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.32.0 (2024-09-19)
+
 Features:
 
 - Make the `FirebaseModule` provide the `FirestoreAdminClient`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.22.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Features:

- Make the `FirebaseModule` provide the `FirestoreAdminClient`.
- Make the `FirestoreHealthIndicator` get the database instead of listing collections.

### Commits

- **🔖 Set version to 0.32.0**
- **📝 Update changelog**