### PR TITLE
🐛 Revert Firestore healthcheck using `GetDatabase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fix:
+
+- Revert the `FirestoreHealthIndicator` getting the database, as this is counted as a database operation with an extremely low quota.
+
 ## v0.32.0 (2024-09-19)
 
 Features:

--- a/src/firestore/healthcheck.ts
+++ b/src/firestore/healthcheck.ts
@@ -2,7 +2,6 @@ import { BaseHealthIndicatorService } from '@causa/runtime/nestjs';
 import { Injectable } from '@nestjs/common';
 import { HealthCheckError, HealthIndicatorResult } from '@nestjs/terminus';
 import { Firestore } from 'firebase-admin/firestore';
-import { FirestoreAdminClient } from '../firebase/index.js';
 
 /**
  * The key used to identify the Firestore health indicator.
@@ -14,30 +13,17 @@ const FIRESTORE_HEALTH_KEY = 'google.firestore';
  */
 @Injectable()
 export class FirestoreHealthIndicator extends BaseHealthIndicatorService {
-  /**
-   * The ID of the database used by Firestore.
-   */
-  private readonly databaseId: string;
-
-  constructor(
-    private readonly admin: FirestoreAdminClient,
-    firestore: Firestore,
-  ) {
+  constructor(private readonly firestore: Firestore) {
     super();
-
-    this.databaseId = firestore.databaseId;
   }
 
   async check(): Promise<HealthIndicatorResult> {
     try {
-      const projectId = await this.admin.getProjectId();
-      const name = this.admin.databasePath(projectId, this.databaseId);
-      await this.admin.getDatabase({ name });
-
+      await this.firestore.listCollections();
       return this.getStatus(FIRESTORE_HEALTH_KEY, true);
     } catch (error: any) {
       throw new HealthCheckError(
-        'Failed to check health by getting Firestore database.',
+        'Failed to check health by listing Firestore collections.',
         this.getStatus(FIRESTORE_HEALTH_KEY, false, {
           error: error.message,
         }),


### PR DESCRIPTION
#98 was a bad idea because `GetDatabase` actually counts as a database operation, which has an extremely low quota.

### Commits

- **Revert "✨ Make the FirestoreHealthIndicator get the database instead of listing collections"**
- **📝 Update changelog**