### PR TITLE
✅ Fix flaky test using Spanner read timestamp

### DIFF
--- a/src/transaction/spanner-pubsub/state-transaction.spec.ts
+++ b/src/transaction/spanner-pubsub/state-transaction.spec.ts
@@ -1,6 +1,7 @@
 import { EntityNotFoundError } from '@causa/runtime';
 import { PreciseDate } from '@google-cloud/precise-date';
 import { Database } from '@google-cloud/spanner';
+import { setTimeout } from 'timers/promises';
 import {
   SpannerColumn,
   SpannerEntityManager,
@@ -278,7 +279,10 @@ describe('SpannerStateTransaction', () => {
     });
 
     it('should use the transaction', async () => {
+      // Ensures `beforeInsertDate` is after the database creation...
       const beforeInsertDate = new PreciseDate();
+      // ...but is in the distant past relative to the insert.
+      await setTimeout(100);
 
       const entity = new MyEntity({ id1: '🕰️', id2: '🔮', value: '🌠' });
       await entityManager.insert(entity);


### PR DESCRIPTION
The title says it all. The point of the test was to use a date in the past to make it look like a row inserted after was not visible. However it probably occurred that the row was inserted "at the same time" as evaluating the date for the read timestamp. This forces a delay between the two.

### Commits

- **✅ Fix flaky test using Spanner read timestamp**