### PR TITLE
🐛 Export `HttpMethod` as value and not just type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Fixes:
+
+- Export `HttpMethod` as value and not just type.
+
 ## v0.33.0 (2024-11-14)
 
 Features:

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
         "@google-cloud/spanner": "^7.16.0",
         "@google-cloud/tasks": "^5.5.1",
         "@grpc/grpc-js": "^1.12.2",
-        "@nestjs/common": "^10.4.7",
+        "@nestjs/common": "^10.4.8",
         "@nestjs/config": "^3.3.0",
-        "@nestjs/core": "^10.4.7",
+        "@nestjs/core": "^10.4.8",
         "@nestjs/passport": "^10.0.3",
         "@nestjs/terminus": "^10.2.3",
         "class-transformer": "^0.5.1",
@@ -31,7 +31,7 @@
         "reflect-metadata": "^0.2.2"
       },
       "devDependencies": {
-        "@nestjs/testing": "^10.4.7",
+        "@nestjs/testing": "^10.4.8",
         "@swc/core": "^1.9.2",
         "@swc/jest": "^0.2.37",
         "@tsconfig/node22": "^22.0.0",
@@ -42,7 +42,7 @@
         "@types/supertest": "^6.0.2",
         "@types/uuid": "^10.0.0",
         "dotenv": "^16.4.5",
-        "eslint": "^9.14.0",
+        "eslint": "9.14.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.2.1",
         "jest": "^29.7.0",
@@ -764,9 +764,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -833,9 +833,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1854,9 +1854,9 @@
       "license": "MIT"
     },
     "node_modules/@nestjs/common": {
-      "version": "10.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.7.tgz",
-      "integrity": "sha512-gIOpjD3Mx8gfYGxYm/RHPcJzqdknNNFCyY+AxzBT3gc5Xvvik1Dn5OxaMGw5EbVfhZgJKVP0n83giUOAlZQe7w==",
+      "version": "10.4.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.4.8.tgz",
+      "integrity": "sha512-PVor9dxihg3F2LMnVNkQu42vUmea2+qukkWXUSumtVKDsBo7X7jnZWXtF5bvNTcYK7IYL4/MM4awNfJVJcJpFg==",
       "license": "MIT",
       "dependencies": {
         "iterare": "1.2.1",
@@ -1898,9 +1898,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "10.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.7.tgz",
-      "integrity": "sha512-AIpQzW/vGGqSLkKvll1R7uaSNv99AxZI2EFyVJPNGDgFsfXaohfV1Ukl6f+s75Km+6Fj/7aNl80EqzNWQCS8Ig==",
+      "version": "10.4.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.8.tgz",
+      "integrity": "sha512-Kdi9rDZdlCkGL2AK9XuJ24bZp2YFV6dWBdogGsAHSP5u95wfnSkhduxHZy6q/i1nFFiLASUHabL8Jwr+bmD22Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1966,9 +1966,9 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "10.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.7.tgz",
-      "integrity": "sha512-q6XDOxZPTZ9cxALcVuKUlRBk+cVEv6dW2S8p2yVre22kpEQxq53/OI8EseDvzObGb6hepZ8+yBY04qoYqSlXNQ==",
+      "version": "10.4.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-10.4.8.tgz",
+      "integrity": "sha512-bDz6wQD9LzGeK6uAAFv9l9AbrpyPwHStNObL8J95HBAXJesOblVlQMBAhdfci1YVMQUfOc36qq0IpRSa1II9Mg==",
       "license": "MIT",
       "dependencies": {
         "body-parser": "1.20.3",
@@ -1987,9 +1987,9 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-8.0.5.tgz",
-      "integrity": "sha512-ZmBdsbQNs3wIN5kCuvAVbz3/ULh3gi814oHTP49uTqAGi1aT0YSatUyncwQOHBOlRT+rwF+TNjoAsZ+twIk/Jw==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-8.0.7.tgz",
+      "integrity": "sha512-zaTMCEZ/CxX7QYF110nTqJsn7eCXp4VI9kv7+AdUcIlBmhhgJpggBw2Mx2p6xVjyz1EoWXGfxxWKnxEyaQwFlg==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "^0.15.0",
@@ -2090,9 +2090,9 @@
       }
     },
     "node_modules/@nestjs/testing": {
-      "version": "10.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.7.tgz",
-      "integrity": "sha512-aS3sQ0v4g8cyHDzW3xJv1+8MiFAkxUNXmnau588IFFI/nBIo/kevLNHNPr85keYekkJ/lwNDW72h8UGg8BYd9w==",
+      "version": "10.4.8",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-10.4.8.tgz",
+      "integrity": "sha512-VusUnVgfY6KUc0gKU7ER9QQ2QyCoO770wcAfgLhtqydezt/w07FvqT6uOtb/Tf4SMfUbxx6AJwte6UUmkewbnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2183,9 +2183,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.27.0.tgz",
-      "integrity": "sha512-CdZ3qmHCwNhFAzjTgHqrDQ44Qxcpz43cVxZRhOs+Ns/79ug+Mr84Bkb626bkJLkA3+BLimA5YAEVRlJC6pFb7g==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.28.0.tgz",
+      "integrity": "sha512-igcl4Ve+F1N2063PJUkesk/GkYyuGIWinYkSyAFTnIj3gzrOgvOA4k747XNdL47HRRL1w/qh7UW8NDuxOLvKFA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -4428,9 +4428,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
-      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4641,9 +4641,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.58",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.58.tgz",
-      "integrity": "sha512-al2l4r+24ZFL7WzyPTlyD0fC33LLzvxqLCwurtBibVPghRGO9hSTl+tis8t1kD7biPiH/en4U0I7o/nQbYeoVA==",
+      "version": "1.5.62",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.62.tgz",
+      "integrity": "sha512-t8c+zLmJHa9dJy96yBZRXGQYoiCEnHYgFwn1asvSPZSUdVxnB62A4RASd7k41ytG3ErFBA0TpHlKg9D9SQBmLg==",
       "dev": true,
       "license": "ISC"
     },
@@ -5386,9 +5386,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5660,9 +5660,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.14.2.tgz",
-      "integrity": "sha512-R+FRIfk1GBo3RdlRYWPdwk8nmtVUOn6+BkDomAC46KoU8kzXzE1HLmOasSCbWUByMMAGkknVF0G5kQ69Vj7dlA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.0.tgz",
+      "integrity": "sha512-7ccSEJFDFO7exFbO6NRyC+xH8/mZ1GZGG2xxx9iHxZWcjUjJpjWxIMw3cofAKcueZ6DATiukmmprD7yavQHOyQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "@google-cloud/spanner": "^7.16.0",
     "@google-cloud/tasks": "^5.5.1",
     "@grpc/grpc-js": "^1.12.2",
-    "@nestjs/common": "^10.4.7",
+    "@nestjs/common": "^10.4.8",
     "@nestjs/config": "^3.3.0",
-    "@nestjs/core": "^10.4.7",
+    "@nestjs/core": "^10.4.8",
     "@nestjs/passport": "^10.0.3",
     "@nestjs/terminus": "^10.2.3",
     "class-transformer": "^0.5.1",
@@ -51,7 +51,7 @@
     "reflect-metadata": "^0.2.2"
   },
   "devDependencies": {
-    "@nestjs/testing": "^10.4.7",
+    "@nestjs/testing": "^10.4.8",
     "@swc/core": "^1.9.2",
     "@swc/jest": "^0.2.37",
     "@tsconfig/node22": "^22.0.0",

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -1,4 +1,4 @@
 export * from './errors.js';
 export { CloudTasksModule } from './module.js';
-export { CloudTasksScheduler } from './scheduler.js';
-export type { HttpMethod, HttpRequest, Task } from './scheduler.js';
+export { CloudTasksScheduler, HttpMethod } from './scheduler.js';
+export type { HttpRequest, Task } from './scheduler.js';


### PR DESCRIPTION
Following #102, `HttpMethod` was exported as a `type` only. However it is an enum for which values should be exported as well.

### Commits

- **⬆️ Upgrade dependencies**
- **🐛 Export HttpMethod as value and not just type**
- **📝 Update changelog**