### PR TITLE
🔖 Prepare v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.34.0 (2024-11-27)
+
 Breaking changes:
 
 - Move and rename the `SpannerTransaction` (from `SpannerPubSubTransaction`) for reuse.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.33.1",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.33.1",
+      "version": "0.34.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.24.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.33.1",
+  "version": "0.34.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Move and rename the `SpannerTransaction` (from `SpannerPubSubTransaction`) for reuse.

Features:

- Implement new `PreparedEvent` feature for the `PubSubPublisher`.
- Define the `SpannerReadWriteTransaction` type to avoid relying directly on the Spanner client.
- Implement the `SpannerOutboxTransactionRunner`.

### Commits

- **🔖 Set version to 0.34.0**
- **📝 Update changelog**