### PR TITLE
📝 Fix suggested DDL for `SpannerOutboxEvent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Chores:
 
 - Set the context for all loggers.
 
+Fixes:
+
+- Fix suggested DDL for `SpannerOutboxEvent`.
+
 ## v0.34.0 (2024-11-27)
 
 Breaking changes:

--- a/src/transaction/spanner-outbox/event.ts
+++ b/src/transaction/spanner-outbox/event.ts
@@ -14,7 +14,7 @@ import { SpannerColumn, SpannerTable } from '../../spanner/index.js';
  *   attributes JSON NOT NULL,
  *   leaseExpiration TIMESTAMP,
  *   -- 20 is the number of shards.
- *   shard INT64 NOT NULL AS (MOD(ABS(FARM_FINGERPRINT(id)), 20)),
+ *   shard INT64 AS (MOD(ABS(FARM_FINGERPRINT(id)), 20)),
  * ) PRIMARY KEY (id);
  * CREATE INDEX OutboxEventsByShardAndLeaseExpiration ON OutboxEvent(shard, leaseExpiration)
  * ```


### PR DESCRIPTION
The title says it all. While the emulator accepts the previously suggested DDL, it is not valid and it is rejected by the actual Spanner API.

### Commits

- **📝 Fix suggested DDL for SpannerOutboxEvent**
- **📝 Update changelog**