### PR TITLE
🔖 Prepare v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.35.0 (2024-11-29)
+
 Breaking changes:
 
 - Configure the `PubSubPublisher` using a Causa `(Pino)Logger`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.34.0",
+      "version": "0.35.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.24.1 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Configure the `PubSubPublisher` using a Causa `(Pino)Logger`.

Chores:

- Set the context for all loggers.

Fixes:

- Fix suggested DDL for `SpannerOutboxEvent`.

### Commits

- **🔖 Set version to 0.35.0**
- **📝 Update changelog**