### PR TITLE
🥅 Catch and log errors when closing the Spanner client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Chores:
 
 - Use the Causa `Logger` and set the context in the `PubSubEventHandlerInterceptor`.
 - Change `PubSubPublisher` logs to avoid conflicting with the `PubSubEventHandlerInterceptor`.
+- Catch and log errors when closing the Spanner client during shutdown.
 
 ## v0.35.1 (2024-12-02)
 


### PR DESCRIPTION
The title says it all. The most probable error is a session leak being detected. However this should not stop the rest of shutdown. The error is therefore logged instead of being thrown.
Additional details is logged for leaks, to ease debugging.

### Commits

- **🥅 Catch and log errors when closing the Spanner client**
- **📝 Update changelog**