### PR TITLE
🔖 Prepare v0.35.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.35.2 (2024-12-03)
+
 Chores:
 
 - Use the Causa `Logger` and set the context in the `PubSubEventHandlerInterceptor`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.35.1",
+      "version": "0.35.2",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.24.2 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Chores:

- Use the Causa `Logger` and set the context in the `PubSubEventHandlerInterceptor`.
- Change `PubSubPublisher` logs to avoid conflicting with the `PubSubEventHandlerInterceptor`.
- Catch and log errors when closing the Spanner client during shutdown.

### Commits

- **🔖 Set version to 0.35.2**
- **📝 Update changelog**