### PR TITLE
🔖 Prepare v0.35.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.35.3 (2024-12-04)
+
 Fixes:
 
 - Adapt to the Causa runtime breaking changes and avoid `OutboxEventTransaction` reuse.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.35.2",
+      "version": "0.35.3",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.25.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.35.2",
+  "version": "0.35.3",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Fixes:

- Adapt to the Causa runtime breaking changes and avoid `OutboxEventTransaction` reuse.

### Commits

- **🔖 Set version to 0.35.3**
- **📝 Update changelog**