### PR TITLE
⚡ Avoid locking the entire `OutboxEvent` table when fetching events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+Features:
+
+- Define common types for functions that optionally accept a transaction.
+
+Fixes:
+
+- Avoid locking the entire `OutboxEvent` table when fetching events.
+
 ## v0.36.0 (2025-02-14)
 
 Features:

--- a/src/spanner/types.ts
+++ b/src/spanner/types.ts
@@ -1,3 +1,8 @@
+import type {
+  SpannerReadOnlyTransaction,
+  SpannerReadWriteTransaction,
+} from './entity-manager.js';
+
 /**
  * A partial Spanner entity instance, where nested objects can also be partial.
  */
@@ -6,3 +11,23 @@ export type RecursivePartialEntity<T> = T extends Date
   : T extends object
     ? Partial<T> | { [P in keyof T]?: RecursivePartialEntity<T[P]> }
     : T;
+
+/**
+ * Option for a function that accepts a Spanner read-only transaction.
+ */
+export type SpannerReadOnlyTransactionOption = {
+  /**
+   * The transaction to use.
+   */
+  readonly transaction?: SpannerReadOnlyTransaction;
+};
+
+/**
+ * Option for a function that accepts a Spanner read-write transaction.
+ */
+export type SpanerReadWriteTransactionOption = {
+  /**
+   * The transaction to use.
+   */
+  readonly transaction?: SpannerReadWriteTransaction;
+};

--- a/src/transaction/spanner-outbox/index.ts
+++ b/src/transaction/spanner-outbox/index.ts
@@ -1,5 +1,8 @@
 export { SpannerOutboxEvent } from './event.js';
 export { SpannerOutboxTransactionModule } from './module.js';
 export { SpannerOutboxTransactionRunner } from './runner.js';
-export type { SpannerOutboxTransaction } from './runner.js';
+export type {
+  SpannerOutboxTransaction,
+  SpannerOutboxTransactionOption,
+} from './runner.js';
 export { SpannerOutboxSender } from './sender.js';

--- a/src/transaction/spanner-outbox/runner.ts
+++ b/src/transaction/spanner-outbox/runner.ts
@@ -18,6 +18,16 @@ export type SpannerOutboxTransaction =
   SpannerTransaction<OutboxEventTransaction>;
 
 /**
+ * Option for a function that accepts a {@link SpannerOutboxTransaction}.
+ */
+export type SpannerOutboxTransactionOption = {
+  /**
+   * The transaction to use.
+   */
+  readonly transaction?: SpannerOutboxTransaction;
+};
+
+/**
  * An {@link OutboxTransactionRunner} that uses a {@link SpannerTransaction} to run transactions.
  * Events are stored in a Spanner table before being published.
  */

--- a/src/transaction/spanner-outbox/sender.spec.ts
+++ b/src/transaction/spanner-outbox/sender.spec.ts
@@ -123,6 +123,7 @@ describe('SpannerOutboxSender', () => {
       expect((sender as any).fetchEventsSql).toContain('`myIdColumn`');
       expect((sender as any).fetchEventsSql).toContain('`myLeaseColumn`');
       expect((sender as any).fetchEventsSql).toContain('FORCE_INDEX=`MyIndex`');
+      expect((sender as any).acquireLeaseSql).toContain('`myLeaseColumn`');
     });
   });
 


### PR DESCRIPTION
This PR changes the SQL queries used to fetch and acquire a lease on outbox events, to avoid holding a lock on the entire `OutboxEvent` table.

### Commits

- **⚡ Avoid locking the entire OutboxEvent table when fetching events**
- **✨ Define common types for functions that optionally accept a transaction**
- **📝 Update changelog**