### PR TITLE
🔖 Prepare v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.39.0 (2025-02-27)
+
 Breaking changes:
 
 - Revert inefficient Spanner outbox optimization part of the previous release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": ">= 0.27.0 < 1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": "github:causa-io/runtime-typescript-google",
   "license": "ISC",


### PR DESCRIPTION
Breaking changes:

- Revert inefficient Spanner outbox optimization part of the previous release.

### Commits

- **🔖 Set version to 0.39.0**
- **📝 Update changelog**