### PR TITLE
💥 `SpannerEntityManager` simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Breaking changes:
 - Adapt the `PubSubFixture` to the `Fixture` and `EventFixture` interfaces.
 - Replace the `overrideAppCheck` test utility with the `AppCheckFixture`.
 - Replace the `GoogleAppFixture` with `createGoogleFixtures`.
+- Remove the nested type feature from the `SpannerEntityManager`.
+- Remove `runInExistingOrNew[ReadOnly]Transaction` in favor of options in `transaction` and `snapshot`.
 
 Features:
 

--- a/src/spanner/column.decorator.spec.ts
+++ b/src/spanner/column.decorator.spec.ts
@@ -13,23 +13,12 @@ type SomeJsonType = {
 };
 
 describe('SpannerColumn', () => {
-  class NestedType {
-    @SpannerColumn()
-    otherColumn!: string;
-  }
-
   class Test {
     @SpannerColumn()
     defaultName!: string;
 
     @SpannerColumn({ name: 'providedName' })
     overriddenName!: string;
-
-    @SpannerColumn({ nestedType: NestedType })
-    nestedColumn!: NestedType;
-
-    @SpannerColumn({ nestedType: NestedType, nullifyNested: true })
-    nullableNestedColumn!: NestedType | null;
 
     @SpannerColumn({ isBigInt: true })
     bigIntColumn!: bigint;
@@ -70,12 +59,6 @@ describe('SpannerColumn', () => {
       expect(actualMetadata).toMatchObject({
         defaultName: { name: 'defaultName' },
         overriddenName: { name: 'providedName' },
-        nestedColumn: {
-          nestedType: NestedType,
-          nullifyNested: false,
-          isJson: false,
-        },
-        nullableNestedColumn: { nestedType: NestedType, nullifyNested: true },
         bigIntColumn: { isBigInt: true },
         regularNumberColumn: { isBigInt: false, isInt: false },
         smallIntNumberColumn: { isInt: true },
@@ -107,8 +90,6 @@ describe('SpannerColumn', () => {
       expect(actualParentColumns).toIncludeSameMembers([
         'defaultName',
         'providedName',
-        'nestedColumn_otherColumn',
-        'nullableNestedColumn_otherColumn',
         'bigIntColumn',
         'regularNumberColumn',
         'smallIntNumberColumn',
@@ -120,8 +101,6 @@ describe('SpannerColumn', () => {
       expect(actualChildColumns).toIncludeSameMembers([
         'defaultName',
         'providedName',
-        'nestedColumn_otherColumn',
-        'nullableNestedColumn_otherColumn',
         'bigIntColumn',
         'regularNumberColumn',
         'smallIntNumberColumn',

--- a/src/spanner/column.decorator.ts
+++ b/src/spanner/column.decorator.ts
@@ -18,17 +18,6 @@ export type SpannerColumnMetadata = {
   name: string;
 
   /**
-   * If the type of the property is a nested type, this is the class for this property.
-   */
-  nestedType?: Type;
-
-  /**
-   * When `true`, sets the property to null if all properties is the nested object are null.
-   * Defaults to `false`.
-   */
-  nullifyNested: boolean;
-
-  /**
    * When `true`, the column is assumed to be of type `INT64` and the value will be safely stored in a `bigint`.
    */
   isBigInt: boolean;
@@ -76,8 +65,6 @@ export function SpannerColumn(options: Partial<SpannerColumnMetadata> = {}) {
 
     metadata[propertyKey] = {
       name: options.name ?? propertyKey,
-      nestedType: options.nestedType,
-      nullifyNested: options.nullifyNested ?? false,
       isInt: options.isInt ?? false,
       isBigInt: options.isBigInt ?? false,
       isPreciseDate,
@@ -128,15 +115,9 @@ export function getSpannerColumnsMetadata(
  * Lists all the columns in the given class, based on {@link SpannerColumn} decorators.
  *
  * @param classType The type for the table.
- * @param namePrefix Used for recursion with nested types, do not use directly.
  * @returns The list of columns for the given class.
  */
-export function getSpannerColumns(classType: Type, namePrefix = ''): string[] {
+export function getSpannerColumns(classType: Type): string[] {
   const columnsMetadata = getSpannerColumnsMetadata(classType);
-
-  return Object.values(columnsMetadata).flatMap((c) =>
-    c.nestedType
-      ? getSpannerColumns(c.nestedType, `${c.name}_`)
-      : `${namePrefix}${c.name}`,
-  );
+  return Object.values(columnsMetadata).flatMap((c) => c.name);
 }

--- a/src/spanner/conversion.spec.ts
+++ b/src/spanner/conversion.spec.ts
@@ -14,8 +14,8 @@ const UNSAFE_INT = BigInt(Number.MAX_SAFE_INTEGER) + 10n;
 const UNSAFE_INT_STR = UNSAFE_INT.toString();
 
 describe('conversion', () => {
-  class ChildEntity {
-    constructor(data: Partial<ChildEntity> = {}) {
+  class RegularEntity {
+    constructor(data: Partial<RegularEntity> = {}) {
       Object.assign(this, data);
     }
 
@@ -24,37 +24,6 @@ describe('conversion', () => {
 
     @SpannerColumn({ name: 'otherName' })
     someName?: number;
-  }
-
-  class ParentEntity {
-    constructor(data: Partial<ParentEntity> = {}) {
-      Object.assign(this, data);
-    }
-
-    @SpannerColumn({ name: 'nestedColumn', nestedType: ChildEntity })
-    childEntity!: ChildEntity | null;
-
-    @SpannerColumn({
-      name: 'nullableNestedColumn',
-      nestedType: ChildEntity,
-      nullifyNested: true,
-    })
-    nullableChildEntity!: ChildEntity | null;
-
-    @SpannerColumn()
-    otherProperty!: boolean;
-  }
-
-  class GrandParentEntity {
-    constructor(data: Partial<GrandParentEntity> = {}) {
-      Object.assign(this, data);
-    }
-
-    @SpannerColumn()
-    highLevelProperty!: string;
-
-    @SpannerColumn({ nestedType: ParentEntity })
-    parentEntity!: ParentEntity | null;
   }
 
   class WrappedNumberEntity {
@@ -126,64 +95,6 @@ describe('conversion', () => {
   }
 
   describe('spannerObjectToInstance', () => {
-    it('should convert a flat plain object back to an instance', () => {
-      const spannerObject = { defaultName: 'value', otherName: 5 };
-
-      const actualInstance = spannerObjectToInstance(
-        spannerObject,
-        ChildEntity,
-      );
-
-      expect(actualInstance).toBeInstanceOf(ChildEntity);
-      expect(actualInstance).toEqual({ defaultName: 'value', someName: 5 });
-    });
-
-    it('should convert a flat plain object to a nested instance', () => {
-      const spannerObject = {
-        nestedColumn_defaultName: 'value',
-        nestedColumn_otherName: 5,
-        nullableNestedColumn_defaultName: null,
-        nullableNestedColumn_otherName: null,
-        otherProperty: true,
-      };
-
-      const actualInstance = spannerObjectToInstance(
-        spannerObject,
-        ParentEntity,
-      );
-
-      expect(actualInstance).toBeInstanceOf(ParentEntity);
-      expect(actualInstance.childEntity).toBeInstanceOf(ChildEntity);
-      expect(actualInstance).toEqual({
-        childEntity: { defaultName: 'value', someName: 5 },
-        nullableChildEntity: null,
-        otherProperty: true,
-      });
-    });
-
-    it('should not nullify a nested entity by default', () => {
-      const spannerObject = {
-        nestedColumn_defaultName: null,
-        nestedColumn_otherName: null,
-        nullableNestedColumn_defaultName: null,
-        nullableNestedColumn_otherName: null,
-        otherProperty: true,
-      };
-
-      const actualInstance = spannerObjectToInstance(
-        spannerObject,
-        ParentEntity,
-      );
-
-      expect(actualInstance).toBeInstanceOf(ParentEntity);
-      expect(actualInstance.childEntity).toBeInstanceOf(ChildEntity);
-      expect(actualInstance).toEqual({
-        childEntity: { defaultName: null, someName: null },
-        nullableChildEntity: null,
-        otherProperty: true,
-      });
-    });
-
     it('should handle big int numbers', () => {
       const spannerObject = {
         someFloat: new Float(1.5),
@@ -287,95 +198,6 @@ describe('conversion', () => {
   });
 
   describe('instanceToSpannerObject', () => {
-    it('should convert a flat entity to a plain object', () => {
-      const instance = new ChildEntity({ defaultName: 'value', someName: 5 });
-
-      const actualSpannerObject = instanceToSpannerObject(
-        instance,
-        ChildEntity,
-      );
-
-      expect(actualSpannerObject).toEqual({
-        defaultName: 'value',
-        otherName: new Float(5),
-      });
-    });
-
-    it('should convert a nested entity to a flat plain object', () => {
-      const childEntity = new ChildEntity({
-        defaultName: 'value',
-        someName: 5,
-      });
-      const instance = new ParentEntity({ childEntity, otherProperty: true });
-
-      const actualSpannerObject = instanceToSpannerObject(
-        instance,
-        ParentEntity,
-      );
-
-      expect(actualSpannerObject).toEqual({
-        nestedColumn_defaultName: 'value',
-        nestedColumn_otherName: new Float(5),
-        otherProperty: true,
-      });
-    });
-
-    it('should set to null all columns for a nested object', () => {
-      const instance = new ParentEntity({
-        otherProperty: true,
-        childEntity: null,
-      });
-
-      const actualSpannerObject = instanceToSpannerObject(
-        instance,
-        ParentEntity,
-      );
-
-      expect(actualSpannerObject).toEqual({
-        nestedColumn_defaultName: null,
-        nestedColumn_otherName: null,
-        otherProperty: true,
-      });
-    });
-
-    it('should set a single defined column in a nested object', () => {
-      const instance = new ParentEntity({
-        otherProperty: true,
-        childEntity: { defaultName: 'test' },
-      });
-
-      const actualSpannerObject = instanceToSpannerObject(
-        instance,
-        ParentEntity,
-      );
-
-      expect(actualSpannerObject).toEqual({
-        nestedColumn_defaultName: 'test',
-        otherProperty: true,
-      });
-    });
-
-    it('should handle a two-level hierarchy', () => {
-      const instance = new GrandParentEntity({
-        highLevelProperty: 'someValue',
-        parentEntity: null,
-      });
-
-      const actualSpannerObject = instanceToSpannerObject(
-        instance,
-        GrandParentEntity,
-      );
-
-      expect(actualSpannerObject).toEqual({
-        highLevelProperty: 'someValue',
-        parentEntity_otherProperty: null,
-        parentEntity_nestedColumn_otherName: null,
-        parentEntity_nestedColumn_defaultName: null,
-        parentEntity_nullableNestedColumn_otherName: null,
-        parentEntity_nullableNestedColumn_defaultName: null,
-      });
-    });
-
     it('should handle bigint', () => {
       const instance = new WrappedNumberEntity({ someBigInt: UNSAFE_INT });
 
@@ -459,55 +281,21 @@ describe('conversion', () => {
     it('should set root-level missing columns to null', () => {
       const actualInstance = copyInstanceWithMissingColumnsToNull(
         { defaultName: 'value' },
-        ChildEntity,
+        RegularEntity,
       );
 
       expect(actualInstance).toEqual({
         defaultName: 'value',
         someName: null,
       });
-      expect(actualInstance).toBeInstanceOf(ChildEntity);
-    });
-
-    it('should set nested missing columns to null', () => {
-      const actualInstance = copyInstanceWithMissingColumnsToNull(
-        { childEntity: { defaultName: 'value' }, otherProperty: true },
-        ParentEntity,
-      );
-
-      expect(actualInstance).toEqual({
-        childEntity: {
-          defaultName: 'value',
-          someName: null,
-        },
-        nullableChildEntity: null,
-        otherProperty: true,
-      });
-      expect(actualInstance).toBeInstanceOf(ParentEntity);
-      expect(actualInstance.childEntity).toBeInstanceOf(ChildEntity);
-    });
-
-    it('should set all nested missing columns to null', () => {
-      const actualInstance = copyInstanceWithMissingColumnsToNull(
-        { nullableChildEntity: { someName: 12 } as any, otherProperty: true },
-        ParentEntity,
-      );
-
-      expect(actualInstance).toEqual({
-        childEntity: { defaultName: null, someName: null },
-        nullableChildEntity: { someName: 12, defaultName: null },
-        otherProperty: true,
-      });
-      expect(actualInstance).toBeInstanceOf(ParentEntity);
-      expect(actualInstance.childEntity).toBeInstanceOf(ChildEntity);
-      expect(actualInstance.nullableChildEntity).toBeInstanceOf(ChildEntity);
+      expect(actualInstance).toBeInstanceOf(RegularEntity);
     });
   });
 
   describe('updateInstanceByColumn', () => {
     it('should update a root-level column', () => {
       const actualInstance = updateInstanceByColumn(
-        new ChildEntity({ defaultName: 'value', someName: 5 }),
+        new RegularEntity({ defaultName: 'value', someName: 5 }),
         { someName: 12 },
       );
 
@@ -515,7 +303,7 @@ describe('conversion', () => {
         defaultName: 'value',
         someName: 12,
       });
-      expect(actualInstance).toBeInstanceOf(ChildEntity);
+      expect(actualInstance).toBeInstanceOf(RegularEntity);
     });
 
     it('should update JSON columns fully', () => {
@@ -531,7 +319,7 @@ describe('conversion', () => {
             new JsonType({ a: 13, b: '🐶', c: new Date('2025-01-01') }),
           ],
         }),
-        { someJsonColumn: { b: '💮' } },
+        { someJsonColumn: { b: '💮' } as any },
       );
 
       expect(actualInstance).toEqual({
@@ -544,74 +332,6 @@ describe('conversion', () => {
       expect(actualInstance).toBeInstanceOf(JsonEntity);
       expect(actualInstance.someJsonColumn).toBeInstanceOf(JsonType);
       expect(actualInstance.someJsonArrayColumn[0]).toBeInstanceOf(JsonType);
-    });
-
-    it('should set nested entities to null', () => {
-      const actualInstance = updateInstanceByColumn(
-        new GrandParentEntity({
-          highLevelProperty: '🌻',
-          parentEntity: new ParentEntity({
-            childEntity: new ChildEntity({
-              defaultName: 'value',
-              someName: 5,
-            }),
-            nullableChildEntity: new ChildEntity({
-              defaultName: 'value',
-              someName: 5,
-            }),
-            otherProperty: true,
-          }),
-        }),
-        { parentEntity: { childEntity: null, nullableChildEntity: null } },
-      );
-
-      expect(actualInstance).toEqual({
-        highLevelProperty: '🌻',
-        parentEntity: {
-          childEntity: {
-            defaultName: null,
-            someName: null,
-          },
-          nullableChildEntity: null,
-          otherProperty: true,
-        },
-      });
-      expect(actualInstance).toBeInstanceOf(GrandParentEntity);
-      expect(actualInstance.parentEntity).toBeInstanceOf(ParentEntity);
-    });
-
-    it('should update a nested column previously set to null', () => {
-      const actualInstance = updateInstanceByColumn(
-        new GrandParentEntity({
-          highLevelProperty: '🌻',
-          parentEntity: new ParentEntity({
-            childEntity: null,
-            nullableChildEntity: null,
-            otherProperty: true,
-          }),
-        }),
-        {
-          highLevelProperty: '💮',
-          parentEntity: { childEntity: { defaultName: 'value' } },
-        },
-      );
-
-      expect(actualInstance).toEqual({
-        highLevelProperty: '💮',
-        parentEntity: {
-          childEntity: {
-            defaultName: 'value',
-            someName: null,
-          },
-          nullableChildEntity: null,
-          otherProperty: true,
-        },
-      });
-      expect(actualInstance).toBeInstanceOf(GrandParentEntity);
-      expect(actualInstance.parentEntity).toBeInstanceOf(ParentEntity);
-      expect(actualInstance.parentEntity?.childEntity).toBeInstanceOf(
-        ChildEntity,
-      );
     });
   });
 });

--- a/src/spanner/conversion.ts
+++ b/src/spanner/conversion.ts
@@ -6,70 +6,41 @@ import {
   type SpannerColumnMetadata,
   getSpannerColumnsMetadata,
 } from './column.decorator.js';
-import type { RecursivePartialEntity } from './types.js';
 
 /**
  * Creates a typed class instance from an object returned by the Spanner API.
  *
  * @param spannerObject The object returned by Spanner that should be converted back to a class instance.
  * @param type The class for the object.
- * @param options Used for recursion and should not be set directly.
  * @returns The created object.
  */
-function spannerObjectToInstanceWithOptions<T>(
+export function spannerObjectToInstance<T>(
   spannerObject: Record<string, any>,
   type: Type<T>,
-  options: {
-    /**
-     * The prefix to add to column names when converting the object.
-     */
-    columnNamePrefix?: string;
-
-    /**
-     * Whether the returned instance should be `null` if all its properties are null.
-     * Default to `false`.
-     */
-    nullifyInstance?: boolean;
-  } = {},
-): T | null {
+): T {
   const columnsMetadata = getSpannerColumnsMetadata(type);
-  const columnNamePrefix = options.columnNamePrefix ?? '';
-  const plain: any = {};
 
-  let hasAtLeastOneNonNullValue = false;
-  Object.entries(columnsMetadata).forEach(([property, columnMetadata]) => {
-    const columnName = `${columnNamePrefix}${columnMetadata.name}`;
+  const plain = Object.fromEntries(
+    Object.entries(columnsMetadata).map(([property, columnMetadata]) => {
+      const columnName = columnMetadata.name;
+      const value = spannerObject[columnName];
 
-    if (columnMetadata.nestedType) {
-      plain[property] = spannerObjectToInstanceWithOptions(
-        spannerObject,
-        columnMetadata.nestedType,
-        {
-          columnNamePrefix: `${columnName}_`,
-          nullifyInstance: columnMetadata.nullifyNested,
-        },
-      );
-    } else if (columnMetadata.isJson) {
-      plain[property] = spannerObject[columnName];
-    } else if (Array.isArray(spannerObject[columnName])) {
-      plain[property] = spannerObject[columnName].map((v: any) =>
-        spannerValueToJavaScript(v, columnMetadata),
-      );
-    } else {
-      plain[property] = spannerValueToJavaScript(
-        spannerObject[columnName],
-        columnMetadata,
-      );
-    }
+      if (columnMetadata.isJson) {
+        return [property, value];
+      }
 
-    if (plain[property] != null) {
-      hasAtLeastOneNonNullValue = true;
-    }
-  });
+      if (Array.isArray(value)) {
+        const values = value.map((v) =>
+          spannerValueToJavaScript(v, columnMetadata),
+        );
+        return [property, values];
+      }
 
-  return hasAtLeastOneNonNullValue || !options.nullifyInstance
-    ? plainToInstance(type, plain)
-    : null;
+      return [property, spannerValueToJavaScript(value, columnMetadata)];
+    }),
+  );
+
+  return plainToInstance(type, plain);
 }
 
 /**
@@ -88,15 +59,19 @@ function spannerValueToJavaScript(
   if (value instanceof Float) {
     // Floats are always safe and can always be unwrapped.
     return value.valueOf();
-  } else if (value instanceof Int) {
+  }
+
+  if (value instanceof Int) {
     if (columnMetadata.isBigInt) {
       return BigInt(value.value);
-    } else {
-      // This unwraps the string to an integer number, but might throw if the integer is above what can be represented
-      // safely as a float.
-      return value.valueOf();
     }
-  } else if (
+
+    // This unwraps the string to an integer number, but might throw if the integer is above what can be represented
+    // safely as a float.
+    return value.valueOf();
+  }
+
+  if (
     value instanceof Date &&
     // `PreciseDate` extends `Date`. This was previously used to handle conflicting versions of `PreciseDate`.
     value.constructor.name === PreciseDate.name &&
@@ -108,21 +83,6 @@ function spannerValueToJavaScript(
   }
 
   return value;
-}
-
-/**
- * Creates a typed class instance from an object returned by the Spanner API.
- *
- * @param spannerObject The object returned by Spanner that should be converted back to a class instance.
- * @param type The class for the object.
- * @returns The created object.
- */
-export function spannerObjectToInstance<T>(
-  spannerObject: Record<string, any>,
-  type: Type<T>,
-): T {
-  // This is okay as `null` can only be returned when the internal option `nullifyInstance` is set.
-  return spannerObjectToInstanceWithOptions(spannerObject, type)!;
 }
 
 /**
@@ -143,11 +103,17 @@ function makeSpannerValue(value: any, metadata: SpannerColumnMetadata): any {
     return Array.isArray(value)
       ? value.map((v) => new Int(v.toString()))
       : new Int(value.toString());
-  } else if (metadata.isJson) {
+  }
+
+  if (metadata.isJson) {
     return JSON.stringify(value);
-  } else if (typeof value === 'number') {
+  }
+
+  if (typeof value === 'number') {
     return new Float(value);
-  } else if (
+  }
+
+  if (
     Array.isArray(value) &&
     value.length > 0 &&
     typeof value[0] === 'number'
@@ -163,106 +129,51 @@ function makeSpannerValue(value: any, metadata: SpannerColumnMetadata): any {
  *
  * @param instance The object to convert to a Spanner object.
  * @param type The type of the object to convert.
- * @param columnNamePrefix The prefix to add to column names. Used for recursion and should not be set directly.
- * @returns A generic JavaScript object that can be passed to the Spanner API.
- */
-export function instanceToSpannerObjectInternal<T>(
-  instance: T | RecursivePartialEntity<T> | null,
-  type: Type<T>,
-  columnNamePrefix = '',
-): Record<string, any> {
-  const columnsMetadata = getSpannerColumnsMetadata(type);
-
-  let spannerObject: Record<string, any> = {};
-
-  Object.entries(columnsMetadata).forEach(([property, columnMetadata]) => {
-    const columnName = `${columnNamePrefix}${columnMetadata.name}`;
-
-    // When the current property value is `undefined`, column(s) values should not be set.
-    if (instance !== null && (instance as any)[property] === undefined) {
-      return;
-    }
-
-    // When the whole instance is `null`, all its child properties should be set to null.
-    const propertyValue =
-      instance === null ? null : (instance as any)[property];
-
-    if (columnMetadata.nestedType) {
-      spannerObject = {
-        ...spannerObject,
-        ...instanceToSpannerObjectInternal(
-          propertyValue,
-          columnMetadata.nestedType,
-          `${columnName}_`,
-        ),
-      };
-    } else {
-      spannerObject[columnName] = makeSpannerValue(
-        propertyValue,
-        columnMetadata,
-      );
-    }
-  });
-
-  return spannerObject;
-}
-
-/**
- * Converts a class object to a plain JavaScript object that can be passed to the Spanner API.
- *
- * @param instance The object to convert to a Spanner object.
- * @param type The type of the object to convert.
  * @returns A generic JavaScript object that can be passed to the Spanner API.
  */
 export function instanceToSpannerObject<T>(
-  instance: T | RecursivePartialEntity<T>,
+  instance: T | Partial<T>,
   type: Type<T>,
 ): Record<string, any> {
-  return instanceToSpannerObjectInternal(instance, type);
+  const columnsMetadata = getSpannerColumnsMetadata(type);
+
+  return Object.fromEntries(
+    Object.entries(columnsMetadata)
+      .map(([p, m]) => [m, (instance as any)[p]] as const)
+      // When the current property value is `undefined`, the column value should not be set.
+      .filter(([, v]) => v !== undefined)
+      .map(([metadata, value]) => [
+        metadata.name,
+        makeSpannerValue(value, metadata),
+      ]),
+  );
 }
 
 /**
- * Copies an instance, recursively setting all columns that are not defined in the instance to `null`.
- * Columns with the {@link SpannerColumnMetadata.nullifyNested} option set to `true` are also set to `null`.
+ * Copies an instance, setting all columns that are not defined in the instance to `null`.
  *
  * @param instance The instance to copy.
  * @param type The type of the instance.
  * @returns The copied instance.
  */
 export function copyInstanceWithMissingColumnsToNull<T>(
-  instance: T | RecursivePartialEntity<T>,
+  instance: T | Partial<T>,
   type: Type<T>,
 ): T {
   const columnsMetadata = getSpannerColumnsMetadata(type);
 
-  const plain: any = {};
-
-  Object.entries(columnsMetadata).forEach(([property, columnMetadata]) => {
-    const instanceValue = instance == null ? null : (instance as any)[property];
-
-    if (columnMetadata.nestedType) {
-      if (columnMetadata.nullifyNested && instanceValue == null) {
-        plain[property] = null;
-      } else {
-        plain[property] = copyInstanceWithMissingColumnsToNull(
-          instanceValue,
-          columnMetadata.nestedType,
-        );
-      }
-    } else if (instanceValue !== undefined) {
-      plain[property] = instanceValue;
-    } else {
-      plain[property] = null;
-    }
-  });
+  const plain = Object.fromEntries(
+    Object.keys(columnsMetadata).map((property) => {
+      const value = (instance as any)[property];
+      return [property, value === undefined ? null : value];
+    }),
+  );
 
   return plainToInstance(type, plain);
 }
 
 /**
- * Recursively updates an instance with the values from the update.
- * Updates are applied "column-wise", which means that recursion stops at properties decorated as columns.
- * For example, JSON values are not affected.
+ * Updates an instance with the values from the update.
  *
  * @param instance The instance to update. It should be a full, typed, instance, unless `type` is passed as well.
  * @param update The update to apply to the instance.
@@ -271,37 +182,22 @@ export function copyInstanceWithMissingColumnsToNull<T>(
  */
 export function updateInstanceByColumn<T>(
   instance: T,
-  update: RecursivePartialEntity<T>,
+  update: Partial<T>,
   type?: Type<T>,
 ): T {
   type ??= (instance as any).constructor as Type<T>;
   const columnsMetadata = getSpannerColumnsMetadata(type);
 
-  const plain: any = {};
-
-  Object.entries(columnsMetadata).forEach(([property, columnMetadata]) => {
-    const instanceValue = instance == null ? null : (instance as any)[property];
-    const updateValue = update == null ? update : (update as any)[property];
-
-    if (updateValue === undefined) {
-      plain[property] = instanceValue;
-      return;
-    }
-
-    if (columnMetadata.nestedType) {
-      if (columnMetadata.nullifyNested && updateValue === null) {
-        plain[property] = null;
-      } else {
-        plain[property] = updateInstanceByColumn(
-          instanceValue,
-          updateValue,
-          columnMetadata.nestedType,
-        );
-      }
-    } else if (updateValue !== undefined) {
-      plain[property] = updateValue;
-    }
-  });
+  const plain = Object.fromEntries(
+    Object.keys(columnsMetadata).map((property) => {
+      const instanceValue = (instance as any)[property];
+      const updateValue = (update as any)[property];
+      return [
+        property,
+        updateValue === undefined ? instanceValue : updateValue,
+      ];
+    }),
+  );
 
   return plainToInstance(type, plain);
 }

--- a/src/spanner/entity-manager.ts
+++ b/src/spanner/entity-manager.ts
@@ -20,7 +20,6 @@ import {
 } from './errors.js';
 import { SpannerTableCache } from './table-cache.js';
 import type {
-  RecursivePartialEntity,
   SpannerReadOnlyTransactionOption,
   SpannerReadWriteTransactionOption,
 } from './types.js';
@@ -135,10 +134,7 @@ export class SpannerEntityManager {
    *   constructor).
    * @returns The primary key of the entity.
    */
-  getPrimaryKey<T>(
-    entity: T | RecursivePartialEntity<T>,
-    entityType?: Type<T>,
-  ): SpannerKey {
+  getPrimaryKey<T>(entity: T | Partial<T>, entityType?: Type<T>): SpannerKey {
     entityType ??= (entity as any).constructor as Type<T>;
     const obj = instanceToSpannerObject(entity, entityType);
     return this.getPrimaryKeyForSpannerObject(obj, entityType);
@@ -283,7 +279,7 @@ export class SpannerEntityManager {
           jsonOptions: { wrapNumbers: true },
           index: options.index,
         });
-        const row: Record<string, any> = rows[0];
+        const row: Record<string, any> | undefined = rows[0];
 
         if (row && options.index && !options.columns) {
           const primaryKey = this.getPrimaryKeyForSpannerObject(
@@ -638,7 +634,7 @@ export class SpannerEntityManager {
    */
   async update<T>(
     entityType: Type<T>,
-    update: RecursivePartialEntity<T>,
+    update: Partial<T>,
     options: SpannerReadWriteTransactionOption &
       Pick<FindOptions, 'includeSoftDeletes'> & {
         /**

--- a/src/spanner/table-cache.spec.ts
+++ b/src/spanner/table-cache.spec.ts
@@ -87,20 +87,5 @@ describe('SpannerTableCache', () => {
         InvalidEntityDefinitionError,
       );
     });
-
-    it('should throw if the soft delete column is nested', () => {
-      @SpannerTable({ primaryKey: ['id'] })
-      class MyEntity {
-        @SpannerColumn()
-        id!: string;
-
-        @SpannerColumn({ softDelete: true, nestedType: Date })
-        deletedAt!: Date | null;
-      }
-
-      expect(() => cache.getMetadata(MyEntity)).toThrow(
-        InvalidEntityDefinitionError,
-      );
-    });
   });
 });

--- a/src/spanner/table-cache.ts
+++ b/src/spanner/table-cache.ts
@@ -76,12 +76,6 @@ export class SpannerTableCache {
         `Only one column can be marked as soft delete.`,
       );
     }
-    if (softDeleteColumns[0]?.nestedType) {
-      throw new InvalidEntityDefinitionError(
-        entityType,
-        `Soft delete columns cannot be nested.`,
-      );
-    }
     const softDeleteColumn = softDeleteColumns[0]?.name ?? null;
 
     const columns = getSpannerColumns(entityType);

--- a/src/spanner/types.ts
+++ b/src/spanner/types.ts
@@ -4,15 +4,6 @@ import type {
 } from './entity-manager.js';
 
 /**
- * A partial Spanner entity instance, where nested objects can also be partial.
- */
-export type RecursivePartialEntity<T> = T extends Date
-  ? T
-  : T extends object
-    ? Partial<T> | { [P in keyof T]?: RecursivePartialEntity<T[P]> }
-    : T;
-
-/**
  * Option for a function that accepts a Spanner read-only transaction.
  */
 export type SpannerReadOnlyTransactionOption = {


### PR DESCRIPTION
### 📝 Description of the PR

This PR:

- Removes the nested type feature from the `SpannerEntityManager`.
- Replaces `runInExistingOrNew[ReadOnly]Transaction` with options in `SpannerEntityManager.transaction` and `SpannerEntityManager.snapshot`.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.