### PR TITLE
✨ Provide a `VersionedEntityFixture` as part of `createGoogleFixtures`

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ The `@IsValidFirestoreId` validation decorator checks that a property is a strin
 
 ### More testing utilities
 
-To include all fixtures provided in this package as part of an `AppFixture`, use the `createGoogleFixtures` function, which is a convenience method to create the fixtures with sensible defaults.
+To include all fixtures provided in this package as part of an `AppFixture`, use the `createGoogleFixtures` function, which is a convenience method to create the fixtures with sensible defaults. This will also automatically provide a `VersionedEntityFixture` configured with the `SpannerOutboxTransactionRunner`.


### PR DESCRIPTION
### 📝 Description of the PR

The title says it all. The fixture is configured for Spanner + Pub/Sub as default, but it can also be configured with Firestore, or simply disabled (not created).

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.