### PR TITLE
🔖 Prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v1.2.0 (2025-10-01)
+
 Features:
 
 - Add the `forProperties` and `alias` options to `SpannerEntityManager.sqlColumns`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### 📝 Description of the PR

Features:

- Add the `forProperties` and `alias` options to `SpannerEntityManager.sqlColumns`.

Chores:

- `SpannerEntityManager.sqlTableName` has been renamed to `SpannerEntityManager.sqlTable`. The previous method is still available but deprecated.

### 📋 Check list

- ~🧪 Unit tests have been written.~
- [x] 📝 Documentation has been updated.