### PR TITLE
🔖 Prepare v2.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v2.0.0-beta.1 (2026-06-10)
+
 Breaking changes:
 
 - Upgrade the minimum Node.js version to `22`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "1.8.0",
+  "version": "2.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "1.8.0",
+      "version": "2.0.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": "^2.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "1.8.0",
+  "version": "2.0.0-beta.1",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Breaking changes:

- Upgrade the minimum Node.js version to `22`.
- Remove the `getDefaultFirebaseApp` utility in favor of `initializeApp`.
- The `@FirestoreCollection` decorator no longer accepts a `name`. Instead, the `path` function returns the full path of a document from the root of the database, as an array of segments.
- Remove the `FirestoreCollectionsModule`, the `@InjectFirestoreCollection` decorator, and the `FirestoreCollectionResolver`. Document and collection references can be obtained from the `Firestore` instance using `getReferenceForFirestoreDocument` and the new `getFirestoreCollection` utility.
- The `FirestoreFixture` no longer creates temporary collections. Instead, it makes the application use a separate Firestore database with a random ID, which is entirely cleared between tests using the Firestore emulator REST API.
- Remove the `firestoreTypes` option from `createGoogleFixtures`.

Features:

- Support the `databaseId` setting in the `FirebaseModule` Firestore options, to use a named database.
- Implement the `clearFirestoreDatabase` testing utility, which clears all documents in a database using the Firestore emulator REST API.

Chores:

- Upgrade dependencies.