### PR TITLE
🐛 Support applications that do not use every Google service in the fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Fixes:
 
 - Ensure `PubSubFixture.expectNoMessage` and `PubSubFixture.clear()` wait for all the published messages, and do not wait for messages that failed to be published.
+- Make `FirestoreFixture.clear()` a no-op when the application does not provide a `Firestore` instance, such that the fixture (and `createGoogleFixtures`) can be used with applications that do not rely on Firestore.
+- Ensure the `PubSubFixture` deletes the temporary topic it created when the corresponding subscription cannot be created.
+- Make the `SpannerFixture` create its temporary database from the factory replacing the `Database` provider, rather than eagerly during initialization. No database is created for applications that do not provide a `Database`.
 
 ## v2.0.0 (2026-06-12)
 

--- a/src/firestore/testing.spec.ts
+++ b/src/firestore/testing.spec.ts
@@ -23,6 +23,9 @@ class TestService {
 })
 class MyModule {}
 
+@Module({})
+class ModuleWithoutFirestore {}
+
 describe('FirestoreFixture', () => {
   let appFixture: AppFixture;
   let fixture: FirestoreFixture;
@@ -77,6 +80,22 @@ describe('FirestoreFixture', () => {
       expect(actualDocument.exists).toBeFalse();
       const actualNestedDocument = await docRef2.get();
       expect(actualNestedDocument.exists).toBeFalse();
+    });
+
+    it('should do nothing if the application does not provide a Firestore instance', async () => {
+      const otherFixture = new FirestoreFixture();
+      const otherAppFixture = new AppFixture(ModuleWithoutFirestore, {
+        fixtures: [otherFixture],
+      });
+      await otherAppFixture.init();
+
+      try {
+        await otherAppFixture.clear();
+
+        expect(() => otherFixture.firestore).toThrow();
+      } finally {
+        await otherAppFixture.delete();
+      }
     });
   });
 

--- a/src/firestore/testing.ts
+++ b/src/firestore/testing.ts
@@ -1,5 +1,4 @@
 import type {
-  AppFixture,
   Fixture,
   NestJsModuleOverrider,
 } from '@causa/runtime/nestjs/testing';
@@ -58,14 +57,14 @@ export async function clearFirestoreDatabase(
  */
 export class FirestoreFixture implements Fixture {
   /**
-   * The parent {@link AppFixture}.
-   */
-  private appFixture!: AppFixture;
-
-  /**
    * The ID of the Firestore database used during tests.
    */
   readonly databaseId: string;
+
+  /**
+   * The {@link Firestore} instance for the test database.
+   */
+  private testFirestore: Firestore | undefined;
 
   constructor(
     options: {
@@ -78,39 +77,57 @@ export class FirestoreFixture implements Fixture {
     this.databaseId = options.databaseId ?? `test-${randomUUID()}`;
   }
 
-  async init(appFixture: AppFixture): Promise<NestJsModuleOverrider> {
-    this.appFixture = appFixture;
-
+  async init(): Promise<NestJsModuleOverrider> {
     return (builder) =>
       builder.overrideProvider(Firestore).useFactory({
-        factory: (app: App, settings: Settings) => {
-          const firestore = createFirestore(app, {
-            ...settings,
-            databaseId: this.databaseId,
-          });
-          // The `FirebaseLifecycleService` is disabled by the `FirebaseFixture`, such that the shared Firebase app is
-          // not deleted. The instance for the test database is however not shared and should be terminated.
-          return Object.assign(firestore, {
-            onApplicationShutdown: () => firestore.terminate(),
-          });
-        },
+        factory: (app: App, settings: Settings) =>
+          this.getOrCreateFirestore(app, settings),
         inject: [FIREBASE_APP_TOKEN, FIRESTORE_SETTINGS_TOKEN],
       });
   }
 
+  /**
+   * Creates the {@link Firestore} instance for the test database if it does not exist yet.
+   *
+   * @param app The Firebase application for which the instance should be created.
+   * @param settings The Firestore settings to use.
+   * @returns The {@link Firestore} instance for the test database.
+   */
+  private getOrCreateFirestore(app: App, settings: Settings): Firestore {
+    this.testFirestore ??= createFirestore(app, {
+      ...settings,
+      databaseId: this.databaseId,
+    });
+
+    return this.testFirestore;
+  }
+
   async clear(): Promise<void> {
-    await clearFirestoreDatabase(this.firestore);
+    if (!this.testFirestore) {
+      return;
+    }
+
+    await clearFirestoreDatabase(this.testFirestore);
   }
 
   async delete(): Promise<void> {
-    this.appFixture = undefined as any;
+    // The `FirebaseLifecycleService` is disabled by the `FirebaseFixture`, such that the shared Firebase app is not
+    // deleted. The instance for the test database is however not shared and should be terminated.
+    await this.testFirestore?.terminate();
+    this.testFirestore = undefined;
   }
 
   /**
    * The underlying {@link Firestore} instance used by this fixture.
    */
   get firestore(): Firestore {
-    return this.appFixture.get(Firestore);
+    if (!this.testFirestore) {
+      throw new Error(
+        'The Firestore instance is not available because the application does not provide one.',
+      );
+    }
+
+    return this.testFirestore;
   }
 
   /**

--- a/src/pubsub/testing.ts
+++ b/src/pubsub/testing.ts
@@ -202,7 +202,15 @@ export class PubSubFixture implements Fixture, EventFixture {
     await this.pubSub.getClientConfig();
 
     const [topic] = await this.pubSub.createTopic(topicName);
-    const [subscription] = await topic.createSubscription(subscriptionName);
+
+    let subscription: Subscription;
+    try {
+      [subscription] = await topic.createSubscription(subscriptionName);
+    } catch (error) {
+      // The topic is not referenced in `topics` yet, which means it would never be deleted by `deleteTopic`.
+      await topic.delete();
+      throw error;
+    }
 
     this.topics[sourceTopic] = { topic, subscription, messages: [] };
 

--- a/src/spanner/testing.spec.ts
+++ b/src/spanner/testing.spec.ts
@@ -1,6 +1,9 @@
+import { AppFixture } from '@causa/runtime/nestjs/testing';
 import { Database, Instance, Spanner } from '@google-cloud/spanner';
+import { Module, type Type } from '@nestjs/common';
 import 'jest-extended';
-import { createDatabase } from './testing.js';
+import { SpannerModule } from './module.js';
+import { createDatabase, SpannerFixture } from './testing.js';
 
 describe('createDatabase', () => {
   let previousEnv: NodeJS.ProcessEnv;
@@ -173,5 +176,80 @@ describe('createDatabase', () => {
       await existingDatabase.delete();
       await actualDatabase.delete();
     }
+  });
+});
+
+describe('SpannerFixture', () => {
+  let fixture: SpannerFixture;
+  let appFixture: AppFixture;
+
+  beforeEach(() => {
+    fixture = new SpannerFixture();
+  });
+
+  afterEach(() => appFixture.delete());
+
+  async function temporaryDatabaseExists(): Promise<boolean> {
+    const database = fixture.instance.database(fixture.name);
+    try {
+      const [exists] = await database.exists();
+      return exists;
+    } finally {
+      await database.close();
+    }
+  }
+
+  it('should create a temporary database and inject it into the application', async () => {
+    @Module({ imports: [SpannerModule.forRoot()] })
+    class ModuleWithSpanner {}
+    appFixture = new AppFixture(ModuleWithSpanner, { fixtures: [fixture] });
+
+    await appFixture.init();
+
+    expect(appFixture.get(Database).formattedName_).toEndWith(
+      `/databases/${fixture.name}`,
+    );
+    expect(await temporaryDatabaseExists()).toBeTrue();
+  });
+
+  it('should not create a database if the application does not provide one', async () => {
+    @Module({})
+    class ModuleWithoutSpanner {}
+    appFixture = new AppFixture(ModuleWithoutSpanner, { fixtures: [fixture] });
+
+    await appFixture.init();
+    await appFixture.clear();
+
+    expect(await temporaryDatabaseExists()).toBeFalse();
+  });
+
+  it('should create a single database if several modules provide it', async () => {
+    function makeDatabaseModule(): Type {
+      @Module({
+        providers: [
+          {
+            provide: Database,
+            useFactory: () => {
+              throw new Error('Should be overridden.');
+            },
+          },
+        ],
+        exports: [Database],
+      })
+      class DatabaseModule {}
+
+      return DatabaseModule;
+    }
+    @Module({ imports: [makeDatabaseModule(), makeDatabaseModule()] })
+    class ModuleWithTwoDatabaseProviders {}
+    appFixture = new AppFixture(ModuleWithTwoDatabaseProviders, {
+      fixtures: [fixture],
+    });
+
+    await appFixture.init();
+
+    const actualDatabases = appFixture.get(Database, { each: true });
+    expect(actualDatabases).toHaveLength(2);
+    expect(actualDatabases[0]).toBe(actualDatabases[1]);
   });
 });

--- a/src/spanner/testing.ts
+++ b/src/spanner/testing.ts
@@ -111,13 +111,14 @@ export class SpannerFixture implements Fixture {
 
   /**
    * The {@link SpannerEntityManager} used to clear tables.
+   * This is only set once the temporary database has been created.
    */
-  private entityManager!: SpannerEntityManager;
+  private entityManager: SpannerEntityManager | undefined;
 
   /**
-   * The temporary test database created by this fixture.
+   * The promise creating the temporary test database.
    */
-  private database!: Database;
+  private databasePromise: Promise<Database> | undefined;
 
   constructor(
     options: Partial<CreateDatabaseParameters> &
@@ -133,24 +134,38 @@ export class SpannerFixture implements Fixture {
   }
 
   async init(): Promise<NestJsModuleOverrider> {
-    this.database = await createDatabase(this);
-
-    this.entityManager = new SpannerEntityManager(this.database);
-
+    // This ensures that the temporary database is only created if the application provides a `Database` (uses Spanner).
     return (builder) =>
-      builder.overrideProvider(Database).useValue(this.database);
+      builder
+        .overrideProvider(Database)
+        .useFactory({ factory: () => this.getOrCreateDatabase() });
+  }
+
+  /**
+   * Creates the temporary test database if it does not exist yet.
+   *
+   * @returns The temporary test {@link Database}.
+   */
+  private getOrCreateDatabase(): Promise<Database> {
+    this.databasePromise ??= createDatabase(this).then((database) => {
+      this.entityManager = new SpannerEntityManager(database);
+      return database;
+    });
+
+    return this.databasePromise;
   }
 
   async clear(): Promise<void> {
-    await this.entityManager.transaction(async (transaction) => {
+    await this.entityManager?.transaction(async (transaction) => {
       for (const entity of this.types) {
-        await this.entityManager.clear(entity, { transaction });
+        await this.entityManager?.clear(entity, { transaction });
       }
     });
   }
 
   async delete(): Promise<void> {
-    await this.database.delete();
+    const database = await this.databasePromise?.catch(() => undefined);
+    await database?.delete();
 
     this.spanner.close();
   }


### PR DESCRIPTION
### 📝 Description of the PR

The fixtures provided by this package assumed that the application under test uses every Google service they cover. In practice, an application that only relies on Spanner and Pub/Sub (or only on Firestore) could not use `createGoogleFixtures`: the `FirestoreFixture` threw during teardown because the application provides no `Firestore`, and the `SpannerFixture` created a temporary Spanner database even though the application never uses one. Working around this meant either adding unused modules to the application, or hand-assembling the list of fixtures that the convenience helper is meant to provide.

The `FirestoreFixture` and the `SpannerFixture` are now tolerant of applications that do not use the corresponding service. Both rely on the fact that overriding a provider the application does not declare has no effect: the `SpannerFixture` creates its temporary database from the factory replacing the `Database` provider rather than eagerly during initialization, so no database is created for an application without Spanner, and the `FirestoreFixture` clears nothing when its factory was never called. `createGoogleFixtures` can therefore be used as-is by applications that rely on any subset of the supported services.

Both fixtures also now create a single instance of their resource even when several modules declare the corresponding provider, and the `FirestoreFixture` terminates its own Firestore instance during teardown rather than relying on a NestJS shutdown hook, so the client is released even when the application failed to start. Finally, the `PubSubFixture` deletes the temporary topic it created when the corresponding subscription cannot be created, which previously left an orphan topic behind.

One behavior worth noting for applications that do not use the modules of this package to provide their clients: because the `SpannerFixture` now replaces the `Database` provider with a factory, it no longer overrides a `Database` declared with `useValue`. Applications using `SpannerModule` are unaffected.

### 📋 Check list

- [x] 🧪 Unit tests have been written.
- [x] 📝 Documentation has been updated.
