### PR TITLE
🔖 Prepare v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v2.0.1 (2026-07-31)
+
 Fixes:
 
 - Ensure `PubSubFixture.expectNoMessage` and `PubSubFixture.clear()` wait for all the published messages, and do not wait for messages that failed to be published.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@causa/runtime-google",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@causa/runtime-google",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@causa/runtime": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
-        "@causa/runtime": "^2.0.0",
+        "@causa/runtime": "^2.0.2",
         "@google-cloud/precise-date": "^5.2.0",
         "@google-cloud/pubsub": "^5.3.1",
         "@google-cloud/spanner": "^8.10.0",
@@ -606,27 +606,40 @@
       }
     },
     "node_modules/@causa/runtime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@causa/runtime/-/runtime-2.0.0.tgz",
-      "integrity": "sha512-93eK1eFNVEdlWF83OwkN1vbv+rxZHl1lnEd32lnblq0FI2aOPyqvUYpRb6esX4Z8HYSX2x2PsUAtxBfTLo/UaA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@causa/runtime/-/runtime-2.0.2.tgz",
+      "integrity": "sha512-Z5A2NM7ZmOCQ73MJCIvwoY8JFjcJ9Vmkcx3ZHxmC0NsMVKd+Auk4ulM7/CecoxBjP3QnLK2x0zgQBFp3JNVv8w==",
       "license": "ISC",
       "dependencies": {
-        "@nestjs/cache-manager": "^3.1.2",
-        "@nestjs/common": "^11.1.26",
+        "@nestjs/cache-manager": "^3.1.3",
+        "@nestjs/common": "^11.1.28",
         "@nestjs/config": "^4.0.4",
-        "@nestjs/core": "^11.1.26",
+        "@nestjs/core": "^11.1.28",
         "@nestjs/passport": "^11.0.5",
-        "@nestjs/platform-express": "^11.1.26",
-        "@nestjs/swagger": "^11.4.4",
+        "@nestjs/platform-express": "^11.1.28",
+        "@nestjs/swagger": "^11.4.6",
         "@nestjs/terminus": "^11.1.1",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
         "express": "^5.2.1",
         "nestjs-pino": "^4.6.1",
         "pino": "^10.3.1",
-        "raw-body": "^3.0.2",
+        "raw-body": "^4.0.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@causa/runtime/node_modules/raw-body": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-4.0.0.tgz",
+      "integrity": "sha512-TMHtwexrgOt9VJ2E5JF9RO8mRXGNgC5wXvKkc5AVSJUt1L5gxvjg7eiCQl96EqUEpCWrnNEkCnbAplYtyuq1IA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "http-errors": "^2.0.1"
       },
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@causa/runtime-google",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An extension to the Causa runtime SDK (`@causa/runtime`), providing Google-specific features.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:cov": "npm run test -- --coverage"
   },
   "dependencies": {
-    "@causa/runtime": "^2.0.0",
+    "@causa/runtime": "^2.0.2",
     "@google-cloud/precise-date": "^5.2.0",
     "@google-cloud/pubsub": "^5.3.1",
     "@google-cloud/spanner": "^8.10.0",


### PR DESCRIPTION
Fixes:

- Ensure `PubSubFixture.expectNoMessage` and `PubSubFixture.clear()` wait for all the published messages, and do not wait for messages that failed to be published.
- Make `FirestoreFixture.clear()` a no-op when the application does not provide a `Firestore` instance, such that the fixture (and `createGoogleFixtures`) can be used with applications that do not rely on Firestore.
- Ensure the `PubSubFixture` deletes the temporary topic it created when the corresponding subscription cannot be created.
- Make the `SpannerFixture` create its temporary database from the factory replacing the `Database` provider, rather than eagerly during initialization. No database is created for applications that do not provide a `Database`.